### PR TITLE
fix span from tmp ref issues

### DIFF
--- a/benchmarks/gradOperator/gradOperator.cpp
+++ b/benchmarks/gradOperator/gradOperator.cpp
@@ -46,17 +46,20 @@ template<typename T>
 void printField(NeoFOAM::Field<T> a)
 {
     std::cout << "a has a size of: " << a.size() << std::endl;
-    auto tmpView = a.copyToHost().span();
+    auto tmpViewHost = a.copyToHost();
+    auto tmpView = tmpViewHost.span();
     for (int i = 0; i < a.size(); i++)
     {
         std::cout << "tmp_view: " << tmpView[i] << " at: " << i << std::endl;
     }
 }
+
 template<>
 void printField(NeoFOAM::Field<NeoFOAM::Vector> a)
 {
     std::cout << "a has a size of: " << a.size() << std::endl;
-    auto tmpView = a.copyToHost().span();
+    auto tmpViewHost = a.copyToHost();
+    auto tmpView = tmpViewHost.span();
     for (int i = 0; i < a.size(); i++)
     {
         std::cout << "tmp_view: " << tmpView[i](0) << " " << tmpView[i](1) << " " << tmpView[i](2)
@@ -83,13 +86,11 @@ int main(int argc, char* argv[])
             T[celli] = celli;
         }
         T.write();
-        // for (int i = 0; i < N; i++)
         {
             addProfiling(foamGradOperator, "foamGradOperator");
             Foam::volVectorField test(Foam::fvc::grad(T));
             test.write();
         }
-
 
         {
             NeoFOAM::Executor exec = NeoFOAM::GPUExecutor();

--- a/include/FoamAdapter/comparison/fieldComparison.hpp
+++ b/include/FoamAdapter/comparison/fieldComparison.hpp
@@ -20,11 +20,12 @@ namespace fvcc = NeoFOAM::finiteVolume::cellCentred;
 #define FIELD_EQUALITY_OPERATOR(NFIELD_TYPE, FFIELD_TYPE)                                          \
     bool operator==(NeoFOAM::Field<NFIELD_TYPE>& nfield, const Foam::Field<FFIELD_TYPE>& ffield)   \
     {                                                                                              \
-        auto hostSpan = nfield.copyToHost().span();                                                \
+        auto hostSpan = nfield.copyToHost();                                                       \
+        auto span = hostSpan.span();                                                               \
                                                                                                    \
-        for (int i = 0; i < hostSpan.size(); i++)                                                  \
+        for (int i = 0; i < span.size(); i++)                                                      \
         {                                                                                          \
-            if (hostSpan[i] != Foam::convert(ffield[i]))                                           \
+            if (span[i] != Foam::convert(ffield[i]))                                               \
             {                                                                                      \
                 return false;                                                                      \
             }                                                                                      \
@@ -41,12 +42,13 @@ FIELD_EQUALITY_OPERATOR(NeoFOAM::Vector, Foam::vector)
         const Foam::GeometricField<FFIELD_TYPE, Foam::fvPatchField, Foam::volMesh>& ffield         \
     )                                                                                              \
     {                                                                                              \
-        auto hostSpan = nfield.internalField().copyToHost().span();                                \
+        auto hostSpan = nfield.internalField().copyToHost();                                       \
+        auto span = hostSpan.span();                                                               \
         const auto& internalFField = ffield.internalField();                                       \
         /* compare internalField*/                                                                 \
-        for (int i = 0; i < hostSpan.size(); i++)                                                  \
+        for (int i = 0; i < span.size(); i++)                                                      \
         {                                                                                          \
-            if (hostSpan[i] != Foam::convert(internalFField[i]))                                   \
+            if (span[i] != Foam::convert(internalFField[i]))                                       \
             {                                                                                      \
                 return false;                                                                      \
             }                                                                                      \
@@ -54,7 +56,8 @@ FIELD_EQUALITY_OPERATOR(NeoFOAM::Vector, Foam::vector)
         /* compare boundaryField */                                                                \
         /* NeoFOAM boundaries are stored in contiguous memory */                                   \
         /* whereas OpenFOAM boundaries are stored in a vector of patches */                        \
-        auto patchValueSpan = nfield.boundaryField().value().copyToHost().span();                  \
+        auto patchValueHost = nfield.boundaryField().value().copyToHost();                         \
+        auto patchValueSpan = patchValueHost.span();                                               \
         NeoFOAM::label pFacei = 0;                                                                 \
         for (const auto& patch : ffield.boundaryField())                                           \
         {                                                                                          \
@@ -81,13 +84,14 @@ VOLGEOFIELD_EQUALITY_OPERATOR(NeoFOAM::Vector, Foam::vector)
         const Foam::GeometricField<FFIELD_TYPE, Foam::fvsPatchField, Foam::surfaceMesh>& ffield    \
     )                                                                                              \
     {                                                                                              \
-        auto hostSpan = nfield.internalField().copyToHost().span();                                \
+        auto hostSpan = nfield.internalField().copyToHost();                                       \
+        auto span = hostSpan.span();                                                               \
         const auto& internalFField = ffield.internalField();                                       \
         /* compare internalField the fvccSurfaceField contains the boundaryValues                  \
          */                                                                                        \
         for (int i = 0; i < internalFField.size(); i++)                                            \
         {                                                                                          \
-            if (hostSpan[i] != Foam::convert(internalFField[i]))                                   \
+            if (span[i] != Foam::convert(internalFField[i]))                                       \
             {                                                                                      \
                 return false;                                                                      \
             }                                                                                      \

--- a/include/FoamAdapter/writers/writers.hpp
+++ b/include/FoamAdapter/writers/writers.hpp
@@ -30,12 +30,9 @@ void copy_impl(DestField& dest, const SrcField src)
 
 void write(NeoFOAM::scalarField& sf, const Foam::fvMesh& mesh, const std::string fieldName)
 {
-    auto copy_impl = [](auto dest, const auto src) {};
-
     Foam::volScalarField* field = mesh.getObjectPtr<Foam::volScalarField>(fieldName);
     if (field)
     {
-        // field is already present and needs to be updated
         detail::copy_impl(field->ref(), sf);
         field->write();
     }
@@ -52,8 +49,7 @@ void write(NeoFOAM::scalarField& sf, const Foam::fvMesh& mesh, const std::string
             mesh,
             Foam::dimensionedScalar(Foam::dimless, 0)
         );
-        Foam::scalarField& field_ref = foamField.ref();
-        detail::copy_impl(field_ref, sf);
+        detail::copy_impl(foamField.ref(), sf);
         foamField.write();
     }
 }
@@ -80,7 +76,7 @@ void write(NeoFOAM::vectorField& sf, const Foam::fvMesh& mesh, const std::string
             mesh,
             Foam::dimensionedVector(Foam::dimless, Foam::Zero)
         );
-        detail::copy_impl(field->ref(), sf);
+        detail::copy_impl(foamField.ref(), sf);
         foamField.write();
     }
 }

--- a/test/catch2/common.hpp
+++ b/test/catch2/common.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "FoamAdapter/conversion/convert.hpp"
+
 #include "NeoFOAM/fields/field.hpp"
 #include "NeoFOAM/fields/boundaryFields.hpp"
 #include "NeoFOAM/fields/domainField.hpp"
@@ -32,6 +34,20 @@ void checkField(const NeoFOAM::Field<ValueType>& field, ValueType value)
         REQUIRE(fieldSpan[i] == value);
     }
 }
+
+template<typename NF_FIELD, typename OF_FIELD>
+void checkField(const NF_FIELD& a, const OF_FIELD& b)
+{
+    auto aHost = a.copyToHost();
+    auto aSpan = aHost.span();
+
+    REQUIRE(a.size() == b.size());
+    for (int i = 0; i < aSpan.size(); i++)
+    {
+        REQUIRE(aSpan[i] == convert(b[i]));
+    }
+}
+
 
 struct ApproxScalar
 {

--- a/test/catch2/common.hpp
+++ b/test/catch2/common.hpp
@@ -24,10 +24,12 @@
 template<typename ValueType>
 void checkField(const NeoFOAM::Field<ValueType>& field, ValueType value)
 {
-    auto field_host = field.copyToHost().span();
-    for (int i = 0; i < field_host.size(); i++)
+    auto fieldHost = field.copyToHost();
+    auto fieldSpan = fieldHost.span();
+
+    for (int i = 0; i < fieldSpan.size(); i++)
     {
-        REQUIRE(field_host[i] == value);
+        REQUIRE(fieldSpan[i] == value);
     }
 }
 

--- a/test/test_operators.cpp
+++ b/test/test_operators.cpp
@@ -90,10 +90,9 @@ TEST_CASE("Interpolation")
             fvcc::SurfaceInterpolation interp(exec, uMesh, std::move(linearKernel));
             interp.interpolate(neoT, neoSurfT);
             auto sNeoSurfTHost = neoSurfT.internalField().copyToHost();
-            auto sNeoSurfT = sNeoSurfTHost.span();
             std::span<Foam::scalar> surfTSpan(surfT.primitiveFieldRef().data(), surfT.size());
             REQUIRE_THAT(
-                sNeoSurfT.subspan(0, surfT.size()),
+                sNeoSurfTHost.span({0, surfT.size()}),
                 Catch::Matchers::RangeEquals(surfTSpan, ApproxScalar(1e-15))
             );
         }
@@ -110,8 +109,6 @@ TEST_CASE("GradOperator")
         NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );
-
-    // NeoFOAM::Executor exec = NeoFOAM::CPUExecutor{};
 
     std::string execName = std::visit([](auto e) { return e.print(); }, exec);
 

--- a/test/test_operators.cpp
+++ b/test/test_operators.cpp
@@ -88,8 +88,9 @@ TEST_CASE("Interpolation")
             auto linearKernel = fvcc::SurfaceInterpolationFactory::create("linear", exec, uMesh);
 
             fvcc::SurfaceInterpolation interp(exec, uMesh, std::move(linearKernel));
-            interp.interpolate(neoSurfT, neoT);
-            auto sNeoSurfT = neoSurfT.internalField().copyToHost().span();
+            interp.interpolate(neoT, neoSurfT);
+            auto sNeoSurfTHost = neoSurfT.internalField().copyToHost();
+            auto sNeoSurfT = sNeoSurfTHost.span();
             std::span<Foam::scalar> surfTSpan(surfT.primitiveFieldRef().data(), surfT.size());
             REQUIRE_THAT(
                 sNeoSurfT.subspan(0, surfT.size()),
@@ -150,10 +151,8 @@ TEST_CASE("GradOperator")
 
         fvcc::VolumeField<NeoFOAM::scalar> neoT = constructFrom(exec, uMesh, t);
         neoT.correctBoundaryConditions();
-        REQUIRE_THAT(
-            neoT.internalField().copyToHost().span(),
-            Catch::Matchers::RangeEquals(sT, ApproxScalar(1e-16))
-        );
+        auto neoTHost = neoT.internalField().copyToHost();
+        REQUIRE_THAT(neoTHost.span(), Catch::Matchers::RangeEquals(sT, ApproxScalar(1e-16)));
 
         fvcc::VolumeField<NeoFOAM::Vector> neoGradT = constructFrom(exec, uMesh, ofGradT);
         NeoFOAM::fill(neoGradT.internalField(), NeoFOAM::Vector(0.0, 0.0, 0.0));
@@ -163,9 +162,9 @@ TEST_CASE("GradOperator")
         write(neoGradT.internalField(), mesh, "gradT_" + execName);
 
         std::span<Foam::vector> sOfGradT(ofGradT.primitiveFieldRef().data(), ofGradT.size());
+        auto neoGradTHost = neoGradT.internalField().copyToHost();
         REQUIRE_THAT(
-            neoGradT.internalField().copyToHost().span(),
-            Catch::Matchers::RangeEquals(sOfGradT, ApproxVector(1e-12))
+            neoGradTHost.span(), Catch::Matchers::RangeEquals(sOfGradT, ApproxVector(1e-12))
         );
     }
 }
@@ -234,17 +233,16 @@ TEST_CASE("DivOperator")
 
         fvcc::SurfaceField<NeoFOAM::scalar> neoPhi = constructSurfaceField(exec, uMesh, phi);
         std::span<Foam::scalar> sPhi(phi.primitiveFieldRef().data(), t.size());
-        const auto sNeoPhiHost = neoPhi.internalField().copyToHost().span();
+        const auto sNeoPhiHost = neoPhi.internalField().copyToHost();
+
         REQUIRE_THAT(
-            sNeoPhiHost.subspan(0, sPhi.size()),
+            sNeoPhiHost.span({0, sPhi.size()}),
             Catch::Matchers::RangeEquals(sPhi, ApproxScalar(1e-15))
         );
 
         neoT.correctBoundaryConditions();
-        REQUIRE_THAT(
-            neoT.internalField().copyToHost().span(),
-            Catch::Matchers::RangeEquals(sT, ApproxScalar(1e-15))
-        );
+        auto neoTHost = neoT.internalField().copyToHost();
+        REQUIRE_THAT(neoTHost.span(), Catch::Matchers::RangeEquals(sT, ApproxScalar(1e-15)));
 
         fvcc::VolumeField<NeoFOAM::scalar> neoDivT = constructFrom(exec, uMesh, ofDivT);
         NeoFOAM::fill(neoDivT.internalField(), 0.0);
@@ -259,9 +257,9 @@ TEST_CASE("DivOperator")
         write(neoDivT.internalField(), mesh, "divT_" + execName);
 
         std::span<Foam::scalar> sOfDivT(ofDivT.primitiveFieldRef().data(), ofDivT.size());
+        auto neoDivTHost = neoDivT.internalField().copyToHost();
         REQUIRE_THAT(
-            neoDivT.internalField().copyToHost().span(),
-            Catch::Matchers::RangeEquals(sOfDivT, ApproxScalar(1e-15))
+            neoDivTHost.span(), Catch::Matchers::RangeEquals(sOfDivT, ApproxScalar(1e-15))
         );
     }
 }

--- a/test/test_unstructuredMesh.cpp
+++ b/test/test_unstructuredMesh.cpp
@@ -48,7 +48,8 @@ TEST_CASE("unstructuredMesh")
 
         SECTION("points")
         {
-            const auto points = uMesh.points().copyToHost().span();
+            const auto pointsHost = uMesh.points().copyToHost();
+            const auto points = pointsHost.span();
             REQUIRE(uMesh.points().size() == mesh.points().size());
             for (int i = 0; i < points.size(); i++)
             {
@@ -59,7 +60,8 @@ TEST_CASE("unstructuredMesh")
 
         SECTION("cellVolumes")
         {
-            const auto cellVolumes = uMesh.cellVolumes().copyToHost().span();
+            const auto cellVolumesHost = uMesh.cellVolumes().copyToHost();
+            const auto cellVolumes = cellVolumesHost.span();
             REQUIRE(cellVolumes.size() == mesh.cellVolumes().size());
             for (int i = 0; i < cellVolumes.size(); i++)
             {
@@ -69,7 +71,8 @@ TEST_CASE("unstructuredMesh")
 
         SECTION("cellCentres")
         {
-            const auto cellCentres = uMesh.cellCentres().copyToHost().span();
+            const auto cellCentresHost = uMesh.cellCentres().copyToHost();
+            const auto cellCentres = cellCentresHost.span();
             REQUIRE(cellCentres.size() == mesh.cellCentres().size());
             for (int i = 0; i < cellCentres.size(); i++)
             {
@@ -79,7 +82,8 @@ TEST_CASE("unstructuredMesh")
 
         SECTION("faceCentres")
         {
-            const auto faceCentres = uMesh.faceCentres().copyToHost().span();
+            const auto faceCentresHost = uMesh.faceCentres().copyToHost();
+            const auto faceCentres = faceCentresHost.span();
             REQUIRE(faceCentres.size() == mesh.faceCentres().size());
             for (int i = 0; i < faceCentres.size(); i++)
             {
@@ -89,7 +93,8 @@ TEST_CASE("unstructuredMesh")
 
         SECTION("faceAreas")
         {
-            const auto faceAreas = uMesh.faceAreas().copyToHost().span();
+            const auto faceAreasHost = uMesh.faceAreas().copyToHost();
+            const auto faceAreas = faceAreasHost.span();
             // REQUIRE(faceAreas.size() == mesh.Sf().size());
             for (int i = 0; i < mesh.Sf().size(); i++)
             {
@@ -97,11 +102,11 @@ TEST_CASE("unstructuredMesh")
             }
         }
 
-
         SECTION("magFaceAreas")
         {
             Foam::scalarField magSf(mag(mesh.faceAreas()));
-            const auto magFaceAreas = uMesh.magFaceAreas().copyToHost().span();
+            const auto magFaceAreasHost = uMesh.magFaceAreas().copyToHost();
+            const auto magFaceAreas = magFaceAreasHost.span();
             REQUIRE(magFaceAreas.size() == magSf.size());
             for (int i = 0; i < magFaceAreas.size(); i++)
             {
@@ -109,10 +114,10 @@ TEST_CASE("unstructuredMesh")
             }
         }
 
-
         SECTION("faceOwner")
         {
-            const auto faceOwner = uMesh.faceOwner().copyToHost().span();
+            const auto faceOwnerHost = uMesh.faceOwner().copyToHost();
+            const auto faceOwner = faceOwnerHost.span();
             REQUIRE(faceOwner.size() == mesh.faceOwner().size());
             for (int i = 0; i < faceOwner.size(); i++)
             {
@@ -122,7 +127,8 @@ TEST_CASE("unstructuredMesh")
 
         SECTION("faceNeighbour")
         {
-            const auto faceNeighbour = uMesh.faceNeighbour().copyToHost().span();
+            const auto faceNeighbourHost = uMesh.faceNeighbour().copyToHost();
+            const auto faceNeighbour = faceNeighbourHost.span();
             REQUIRE(faceNeighbour.size() == mesh.faceNeighbour().size());
             for (int i = 0; i < faceNeighbour.size(); i++)
             {
@@ -150,7 +156,8 @@ TEST_CASE("unstructuredMesh")
         // TODO: prettify the following tests
         SECTION("faceCells")
         {
-            auto faceCells = bMesh.faceCells().copyToHost().span();
+            auto faceCellsHost = bMesh.faceCells().copyToHost();
+            auto faceCells = faceCellsHost.span();
             forAll(bMeshOF, patchi)
             {
                 const Foam::fvPatch& patchOF = bMeshOF[patchi];
@@ -166,7 +173,8 @@ TEST_CASE("unstructuredMesh")
 
         SECTION("Cf")
         {
-            const auto& cf = bMesh.cf().copyToHost().span();
+            const auto& cfHost = bMesh.cf().copyToHost();
+            const auto& cf = cfHost.span();
             forAll(bMeshOF, patchi)
             {
                 const Foam::fvPatch& patchOF = bMeshOF[patchi];
@@ -184,7 +192,8 @@ TEST_CASE("unstructuredMesh")
 
         SECTION("Cn")
         {
-            const auto& cn = bMesh.cn().copyToHost().span();
+            const auto& cnHost = bMesh.cn().copyToHost();
+            const auto& cn = cnHost.span();
             forAll(bMeshOF, patchi)
             {
                 const Foam::fvPatch& patchOF = bMeshOF[patchi];
@@ -202,7 +211,8 @@ TEST_CASE("unstructuredMesh")
 
         SECTION("Sf")
         {
-            const auto& sF = bMesh.sf().copyToHost().span();
+            const auto& sFHost = bMesh.sf().copyToHost();
+            const auto& sF = sFHost.span();
             forAll(bMeshOF, patchi)
             {
                 const Foam::fvPatch& patchOF = bMeshOF[patchi];
@@ -220,7 +230,8 @@ TEST_CASE("unstructuredMesh")
 
         SECTION("magSf")
         {
-            const auto& magSf = bMesh.magSf().copyToHost().span();
+            const auto& magSfHost = bMesh.magSf().copyToHost();
+            const auto& magSf = magSfHost.span();
             forAll(bMeshOF, patchi)
             {
                 const Foam::fvPatch& patchOF = bMeshOF[patchi];
@@ -236,7 +247,8 @@ TEST_CASE("unstructuredMesh")
 
         SECTION("nf")
         {
-            const auto& nf = bMesh.nf().copyToHost().span();
+            const auto& nfHost = bMesh.nf().copyToHost();
+            const auto& nf = nfHost.span();
             forAll(bMeshOF, patchi)
             {
                 const Foam::fvPatch& patchOF = bMeshOF[patchi];
@@ -254,8 +266,8 @@ TEST_CASE("unstructuredMesh")
 
         SECTION("delta")
         {
-            const auto& delta = bMesh.delta().copyToHost().span();
-            ;
+            const auto& deltaHost = bMesh.delta().copyToHost();
+            const auto& delta = deltaHost.span();
             forAll(bMeshOF, patchi)
             {
                 const Foam::fvPatch& patchOF = bMeshOF[patchi];
@@ -273,7 +285,8 @@ TEST_CASE("unstructuredMesh")
 
         SECTION("weights")
         {
-            const auto& weights = bMesh.weights().copyToHost().span();
+            const auto& weightsHost = bMesh.weights().copyToHost();
+            const auto& weights = weightsHost.span();
             forAll(bMeshOF, patchi)
             {
                 const Foam::fvPatch& patchOF = bMeshOF[patchi];
@@ -289,8 +302,8 @@ TEST_CASE("unstructuredMesh")
 
         SECTION("deltaCoeffs")
         {
-            const auto& deltaCoeffs = bMesh.deltaCoeffs().copyToHost().span();
-            ;
+            const auto& deltaCoeffsHost = bMesh.deltaCoeffs().copyToHost();
+            const auto& deltaCoeffs = deltaCoeffsHost.span();
             forAll(bMeshOF, patchi)
             {
                 const Foam::fvPatch& patchOF = bMeshOF[patchi];
@@ -329,7 +342,8 @@ TEST_CASE("fvccGeometryScheme")
         scheme.update(); // make sure it uptodate
         auto foamWeights = mesh.weights();
 
-        auto weights = scheme.weights().internalField().copyToHost().span();
+        auto weightsHost = scheme.weights().internalField().copyToHost();
+        auto weights = weightsHost.span();
         std::span<Foam::scalar> sFoamWeights(
             foamWeights.primitiveFieldRef().data(), foamWeights.size()
         );
@@ -346,7 +360,8 @@ TEST_CASE("fvccGeometryScheme")
         scheme.update(); // make sure it uptodate
         auto foamWeights = mesh.weights();
 
-        auto weights = scheme.weights().internalField().copyToHost().span();
+        auto weightsHost = scheme.weights().internalField().copyToHost();
+        auto weights = weightsHost.span();
         std::span<Foam::scalar> sFoamWeights(
             foamWeights.primitiveFieldRef().data(), foamWeights.size()
         );

--- a/test/test_unstructuredMesh.cpp
+++ b/test/test_unstructuredMesh.cpp
@@ -46,95 +46,25 @@ TEST_CASE("unstructuredMesh")
 
         REQUIRE(nInternalFaces == mesh.nInternalFaces());
 
-        SECTION("points")
-        {
-            const auto pointsHost = uMesh.points().copyToHost();
-            const auto points = pointsHost.span();
-            REQUIRE(uMesh.points().size() == mesh.points().size());
-            for (int i = 0; i < points.size(); i++)
-            {
-                REQUIRE(points[i] == convert(mesh.points()[i]));
-            }
-        }
+        SECTION("points") { checkField(uMesh.points(), mesh.points()); }
 
+        SECTION("cellVolumes") { checkField(uMesh.cellVolumes(), mesh.cellVolumes()); }
 
-        SECTION("cellVolumes")
-        {
-            const auto cellVolumesHost = uMesh.cellVolumes().copyToHost();
-            const auto cellVolumes = cellVolumesHost.span();
-            REQUIRE(cellVolumes.size() == mesh.cellVolumes().size());
-            for (int i = 0; i < cellVolumes.size(); i++)
-            {
-                REQUIRE(cellVolumes[i] == mesh.cellVolumes()[i]);
-            }
-        }
+        SECTION("cellCentres") { checkField(uMesh.cellCentres(), mesh.cellCentres()); }
 
-        SECTION("cellCentres")
-        {
-            const auto cellCentresHost = uMesh.cellCentres().copyToHost();
-            const auto cellCentres = cellCentresHost.span();
-            REQUIRE(cellCentres.size() == mesh.cellCentres().size());
-            for (int i = 0; i < cellCentres.size(); i++)
-            {
-                REQUIRE(cellCentres[i] == convert(mesh.cellCentres()[i]));
-            }
-        }
+        SECTION("faceCentres") { checkField(uMesh.faceCentres(), mesh.faceCentres()); }
 
-        SECTION("faceCentres")
-        {
-            const auto faceCentresHost = uMesh.faceCentres().copyToHost();
-            const auto faceCentres = faceCentresHost.span();
-            REQUIRE(faceCentres.size() == mesh.faceCentres().size());
-            for (int i = 0; i < faceCentres.size(); i++)
-            {
-                REQUIRE(faceCentres[i] == convert(mesh.faceCentres()[i]));
-            }
-        }
-
-        SECTION("faceAreas")
-        {
-            const auto faceAreasHost = uMesh.faceAreas().copyToHost();
-            const auto faceAreas = faceAreasHost.span();
-            // REQUIRE(faceAreas.size() == mesh.Sf().size());
-            for (int i = 0; i < mesh.Sf().size(); i++)
-            {
-                REQUIRE(faceAreas[i] == convert(mesh.Sf()[i]));
-            }
-        }
+        SECTION("faceAreas") { checkField(uMesh.faceAreas(), mesh.faceAreas()); }
 
         SECTION("magFaceAreas")
         {
             Foam::scalarField magSf(mag(mesh.faceAreas()));
-            const auto magFaceAreasHost = uMesh.magFaceAreas().copyToHost();
-            const auto magFaceAreas = magFaceAreasHost.span();
-            REQUIRE(magFaceAreas.size() == magSf.size());
-            for (int i = 0; i < magFaceAreas.size(); i++)
-            {
-                REQUIRE(magFaceAreas[i] == magSf[i]);
-            }
+            checkField(uMesh.magFaceAreas(), magSf);
         }
 
-        SECTION("faceOwner")
-        {
-            const auto faceOwnerHost = uMesh.faceOwner().copyToHost();
-            const auto faceOwner = faceOwnerHost.span();
-            REQUIRE(faceOwner.size() == mesh.faceOwner().size());
-            for (int i = 0; i < faceOwner.size(); i++)
-            {
-                REQUIRE(faceOwner[i] == mesh.faceOwner()[i]);
-            }
-        }
+        SECTION("faceOwner") { checkField(uMesh.faceOwner(), mesh.faceOwner()); }
 
-        SECTION("faceNeighbour")
-        {
-            const auto faceNeighbourHost = uMesh.faceNeighbour().copyToHost();
-            const auto faceNeighbour = faceNeighbourHost.span();
-            REQUIRE(faceNeighbour.size() == mesh.faceNeighbour().size());
-            for (int i = 0; i < faceNeighbour.size(); i++)
-            {
-                REQUIRE(faceNeighbour[i] == mesh.faceNeighbour()[i]);
-            }
-        }
+        SECTION("faceNeighbour") { checkField(uMesh.faceNeighbour(), mesh.faceNeighbour()); }
     }
 
     SECTION("boundaryMesh" + execName)
@@ -157,13 +87,12 @@ TEST_CASE("unstructuredMesh")
         SECTION("faceCells")
         {
             auto faceCellsHost = bMesh.faceCells().copyToHost();
-            auto faceCells = faceCellsHost.span();
             forAll(bMeshOF, patchi)
             {
                 const Foam::fvPatch& patchOF = bMeshOF[patchi];
                 NeoFOAM::label start = bMesh.offset()[patchi];
                 NeoFOAM::label end = bMesh.offset()[patchi + 1];
-                auto pFaceCells = faceCells.subspan(start, end - start);
+                auto pFaceCells = faceCellsHost.span({start, end});
                 forAll(patchOF.faceCells(), i)
                 {
                     REQUIRE(pFaceCells[i] == patchOF.faceCells()[i]);
@@ -174,13 +103,12 @@ TEST_CASE("unstructuredMesh")
         SECTION("Cf")
         {
             const auto& cfHost = bMesh.cf().copyToHost();
-            const auto& cf = cfHost.span();
             forAll(bMeshOF, patchi)
             {
                 const Foam::fvPatch& patchOF = bMeshOF[patchi];
                 NeoFOAM::label start = bMesh.offset()[patchi];
                 NeoFOAM::label end = bMesh.offset()[patchi + 1];
-                auto pCf = cf.subspan(start, end - start);
+                auto pCf = cfHost.span({start, end});
                 forAll(patchOF.Cf(), i)
                 {
                     REQUIRE(pCf[i][0] == patchOF.Cf()[i][0]);
@@ -193,13 +121,12 @@ TEST_CASE("unstructuredMesh")
         SECTION("Cn")
         {
             const auto& cnHost = bMesh.cn().copyToHost();
-            const auto& cn = cnHost.span();
             forAll(bMeshOF, patchi)
             {
                 const Foam::fvPatch& patchOF = bMeshOF[patchi];
                 NeoFOAM::label start = bMesh.offset()[patchi];
                 NeoFOAM::label end = bMesh.offset()[patchi + 1];
-                auto pCn = cn.subspan(start, end - start);
+                auto pCn = cnHost.span({start, end});
                 forAll(patchOF.Cn()(), i)
                 {
                     REQUIRE(pCn[i][0] == patchOF.Cn()()[i][0]);
@@ -212,13 +139,12 @@ TEST_CASE("unstructuredMesh")
         SECTION("Sf")
         {
             const auto& sFHost = bMesh.sf().copyToHost();
-            const auto& sF = sFHost.span();
             forAll(bMeshOF, patchi)
             {
                 const Foam::fvPatch& patchOF = bMeshOF[patchi];
                 NeoFOAM::label start = bMesh.offset()[patchi];
                 NeoFOAM::label end = bMesh.offset()[patchi + 1];
-                auto pSf = sF.subspan(start, end - start);
+                auto pSf = sFHost.span({start, end});
                 forAll(patchOF.Sf(), i)
                 {
                     REQUIRE(pSf[i][0] == patchOF.Sf()[i][0]);
@@ -231,13 +157,12 @@ TEST_CASE("unstructuredMesh")
         SECTION("magSf")
         {
             const auto& magSfHost = bMesh.magSf().copyToHost();
-            const auto& magSf = magSfHost.span();
             forAll(bMeshOF, patchi)
             {
                 const Foam::fvPatch& patchOF = bMeshOF[patchi];
                 NeoFOAM::label start = bMesh.offset()[patchi];
                 NeoFOAM::label end = bMesh.offset()[patchi + 1];
-                auto pMagSf = magSf.subspan(start, end - start);
+                auto pMagSf = magSfHost.span({start, end});
                 forAll(patchOF.magSf(), i)
                 {
                     REQUIRE(pMagSf[i] == patchOF.magSf()[i]);
@@ -248,13 +173,12 @@ TEST_CASE("unstructuredMesh")
         SECTION("nf")
         {
             const auto& nfHost = bMesh.nf().copyToHost();
-            const auto& nf = nfHost.span();
             forAll(bMeshOF, patchi)
             {
                 const Foam::fvPatch& patchOF = bMeshOF[patchi];
                 NeoFOAM::label start = bMesh.offset()[patchi];
                 NeoFOAM::label end = bMesh.offset()[patchi + 1];
-                auto pNf = nf.subspan(start, end - start);
+                auto pNf = nfHost.span({start, end});
                 forAll(patchOF.nf()(), i)
                 {
                     REQUIRE(pNf[i][0] == patchOF.nf()()[i][0]);
@@ -267,13 +191,12 @@ TEST_CASE("unstructuredMesh")
         SECTION("delta")
         {
             const auto& deltaHost = bMesh.delta().copyToHost();
-            const auto& delta = deltaHost.span();
             forAll(bMeshOF, patchi)
             {
                 const Foam::fvPatch& patchOF = bMeshOF[patchi];
                 NeoFOAM::label start = bMesh.offset()[patchi];
                 NeoFOAM::label end = bMesh.offset()[patchi + 1];
-                auto pDelta = delta.subspan(start, end - start);
+                auto pDelta = deltaHost.span({start, end});
                 forAll(patchOF.delta()(), i)
                 {
                     REQUIRE(pDelta[i][0] == patchOF.delta()()[i][0]);
@@ -286,13 +209,12 @@ TEST_CASE("unstructuredMesh")
         SECTION("weights")
         {
             const auto& weightsHost = bMesh.weights().copyToHost();
-            const auto& weights = weightsHost.span();
             forAll(bMeshOF, patchi)
             {
                 const Foam::fvPatch& patchOF = bMeshOF[patchi];
                 NeoFOAM::label start = bMesh.offset()[patchi];
                 NeoFOAM::label end = bMesh.offset()[patchi + 1];
-                auto pWeights = weights.subspan(start, end - start);
+                auto pWeights = weightsHost.span({start, end});
                 forAll(patchOF.weights(), i)
                 {
                     REQUIRE(pWeights[i] == patchOF.weights()[i]);
@@ -303,13 +225,12 @@ TEST_CASE("unstructuredMesh")
         SECTION("deltaCoeffs")
         {
             const auto& deltaCoeffsHost = bMesh.deltaCoeffs().copyToHost();
-            const auto& deltaCoeffs = deltaCoeffsHost.span();
             forAll(bMeshOF, patchi)
             {
                 const Foam::fvPatch& patchOF = bMeshOF[patchi];
                 NeoFOAM::label start = bMesh.offset()[patchi];
                 NeoFOAM::label end = bMesh.offset()[patchi + 1];
-                auto pDeltaCoeffs = deltaCoeffs.subspan(start, end - start);
+                auto pDeltaCoeffs = deltaCoeffsHost.span({start, end});
                 forAll(patchOF.deltaCoeffs(), i)
                 {
                     REQUIRE(pDeltaCoeffs[i] == patchOF.deltaCoeffs()[i]);
@@ -343,12 +264,11 @@ TEST_CASE("fvccGeometryScheme")
         auto foamWeights = mesh.weights();
 
         auto weightsHost = scheme.weights().internalField().copyToHost();
-        auto weights = weightsHost.span();
         std::span<Foam::scalar> sFoamWeights(
             foamWeights.primitiveFieldRef().data(), foamWeights.size()
         );
         REQUIRE_THAT(
-            weights.subspan(0, foamWeights.size()),
+            weightsHost.span({0, foamWeights.size()}),
             Catch::Matchers::RangeEquals(sFoamWeights, ApproxScalar(1e-16))
         );
     }
@@ -361,12 +281,11 @@ TEST_CASE("fvccGeometryScheme")
         auto foamWeights = mesh.weights();
 
         auto weightsHost = scheme.weights().internalField().copyToHost();
-        auto weights = weightsHost.span();
         std::span<Foam::scalar> sFoamWeights(
             foamWeights.primitiveFieldRef().data(), foamWeights.size()
         );
         REQUIRE_THAT(
-            weights.subspan(0, foamWeights.size()),
+            weightsHost.span({0, foamWeights.size()}),
             Catch::Matchers::RangeEquals(sFoamWeights, ApproxScalar(1e-16))
         );
     }


### PR DESCRIPTION
This PR updates FoamAdapter to work with the head of NeoFOAM. It removes all .span() calls from temporary references.