### PR TITLE
FIX: executor selection

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -38,6 +38,7 @@
         "NEOFOAM_DEVEL_TOOLS": "ON",
         "FOAMADAPTER_BUILD_TESTS": "ON",
         "FOAMADAPTER_BUILD_BENCHMARKS": "ON",
+        "FOAMADAPTER_BUILD_EXAMPLES": "ON",
         "Kokkos_ENABLE_DEBUG": "ON",
         "Kokkos_ENABLE_DEBUG_BOUNDS_CHECK": "ON"
       },
@@ -58,6 +59,7 @@
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "FOAMADAPTER_BUILD_TESTS": "ON",
         "FOAMADAPTER_BUILD_BENCHMARKS": "ON",
+        "FOAMADAPTER_BUILD_EXAMPLES": "ON",
         "NEOFOAM_ENABLE_WARNINGS": "OFF",
         "CMAKE_CXX_FLAGS": "-fno-omit-frame-pointer $env{CXXFLAGS}"
       }

--- a/src/setup.cpp
+++ b/src/setup.cpp
@@ -65,24 +65,29 @@ std::unique_ptr<fvMesh> createMesh(const Time& runTime)
 
 NeoFOAM::Executor createExecutor(const dictionary& dict)
 {
-    auto execName = dict.get<word>("executor");
-    if (execName == "Serial")
+    auto exec_name = dict.get<Foam::word>("executor");
+    Foam::Info << "Creating Executor: " << exec_name << Foam::endl;
+    if (exec_name == "Serial")
     {
+        Foam::Info << "Serial Executor" << Foam::endl;
         return NeoFOAM::SerialExecutor();
     }
-    else if (execName == "CPU")
+    if (exec_name == "CPU")
     {
+        Foam::Info << "CPU Executor" << Foam::endl;
         return NeoFOAM::CPUExecutor();
     }
-    else if (execName == "GPU")
+    if (exec_name == "GPU")
     {
+        Foam::Info << "GPU Executor" << Foam::endl;
         return NeoFOAM::GPUExecutor();
     }
-    else
-    {
-        FatalError << "Executor not recognized" << endl;
-    }
+    Foam::FatalError << "unknown Executor: " << exec_name << Foam::nl
+                     << "Available executors: Serial, CPU, GPU" << Foam::nl
+                     << Foam::abort(Foam::FatalError);
+
     return NeoFOAM::SerialExecutor();
+
 }
 
 }

--- a/tutorials/scalarAdvection/Allrun
+++ b/tutorials/scalarAdvection/Allrun
@@ -10,6 +10,6 @@ mesh=$2
 
 runApplication blockMesh
 
-runApplication ../../../build/ReleaseCudaAll/bin/scalarAdvection
+runApplication ../../build/profiling/bin/scalarAdvection
 
 #------------------------------------------------------------------------------

--- a/tutorials/scalarAdvection/system/controlDict
+++ b/tutorials/scalarAdvection/system/controlDict
@@ -16,7 +16,7 @@ FoamFile
 
 application     laplacianFoam;
 
-executor        CPU;
+executor        Serial;
 
 startFrom       startTime;
 


### PR DESCRIPTION
FIXES:
*  the selection of the executor
* FOAMADAPTER_BUILD_EXAMPLES was not set in cmake presets
