### PR TITLE
fix warning when proper OF version installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ project(
 if(NOT DEFINED ENV{FOAM_SRC})
   message(FATAL_ERROR "You must source OpenFOAM before building FOAM_ADAPTER")
 endif()
-if(NOT ENV{FOAM_API} STREQUAL "2406")
+if(NOT "$ENV{FOAM_API}" STREQUAL "2406")
   message(WARNING "OpenFOAM version != 2406")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,8 @@ project(
 if(NOT DEFINED ENV{FOAM_SRC})
   message(FATAL_ERROR "You must source OpenFOAM before building FOAM_ADAPTER")
 endif()
-if(NOT "$ENV{FOAM_API}" STREQUAL "2406")
-  message(WARNING "OpenFOAM version != 2406")
+if(NOT $ENV{FOAM_API} GREATER_EQUAL 2406)
+  message(WARNING "OpenFOAM version < 2406")
 endif()
 
 option(FOAMADAPTER_BUILD_EXAMPLES "Build the NeoFOAM examples" OFF)


### PR DESCRIPTION
Fixes wrong warning about OpenFOAM version.

On Rocky Linux 9.4, cmake 3.26.5 prompted the warning
```
CMake Warning at CMakeLists.txt:16 (message):
  OpenFOAM version != 2406
```

Further, actual condition could be enhanced when replacing by
```
if(NOT "$ENV{FOAM_API}" GREATER "2312")
  message(WARNING "OpenFOAM version < 2406")
endif()
```
or equivalent solutions.
