### PR TITLE
Fix: amiguous sqrt 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,20 @@ if(NOT $ENV{FOAM_API} GREATER_EQUAL 2406)
   message(WARNING "OpenFOAM version < 2406")
 endif()
 
+# Print C Compiler and version
+message("C Compiler: ${CMAKE_C_COMPILER}")
+execute_process(COMMAND ${CMAKE_C_COMPILER} --version
+                OUTPUT_VARIABLE C_COMPILER_VERSION
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+message("C Compiler Version: ${C_COMPILER_VERSION}")
+
+# Print C++ Compiler and version
+message("C++ Compiler: ${CMAKE_CXX_COMPILER}")
+execute_process(COMMAND ${CMAKE_CXX_COMPILER} --version
+                OUTPUT_VARIABLE CXX_COMPILER_VERSION
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+message("C++ Compiler Version: ${CXX_COMPILER_VERSION}")
+
 option(FOAMADAPTER_BUILD_EXAMPLES "Build the NeoFOAM examples" OFF)
 option(FOAMADAPTER_BUILD_TESTS "Build the unit tests" OFF)
 option(FOAMADAPTER_BUILD_BENCHMARKS "Build benchmarks" OFF)


### PR DESCRIPTION
This solve the ambiguous error with with cuda 12.6 and of2406:

- [ ] gcc + nvcc
- [x] clang + nvcc

How to change the compiler in **CMakePresets.json**:

clang-18 (has to match the clang version and be included the in the path variable)
```
  "configurePresets": [
    {
      "name": "base",
      "hidden": true,
      "binaryDir": "${sourceDir}/build/${presetName}",
      "cacheVariables": {
        "Kokkos_ENABLE_SERIAL": "ON",
        "CMAKE_C_COMPILER": "clang-18",
        "CMAKE_CXX_COMPILER": "clang++-18"
      },
      "generator": "Ninja"
    },
```

gcc (has to match the clang version and be included the in the path variable)
```
  "configurePresets": [
    {
      "name": "base",
      "hidden": true,
      "binaryDir": "${sourceDir}/build/${presetName}",
      "cacheVariables": {
        "Kokkos_ENABLE_SERIAL": "ON",
        "CMAKE_C_COMPILER": "gcc",
        "CMAKE_CXX_COMPILER": "g++
      },
      "generator": "Ninja"
    },
```