### PR TITLE
FIX: segfault writing nf field

### DIFF
--- a/include/FoamAdapter/writers.hpp
+++ b/include/FoamAdapter/writers.hpp
@@ -20,7 +20,7 @@ void copy_impl(DestField& dest, const SrcField src)
 {
     NF_ASSERT_EQUAL(dest.size(), src.size());
     auto src_host = src.copyToHost();
-    auto src_span = src.span();
+    auto src_span = src_host.span();
     for (int i = 0; i < dest.size(); i++)
     {
         dest[i] = convert(src_span[i]);


### PR DESCRIPTION
Writing a GPU field result in a seg fault as the memory on the GPU was accessed instead of the host field