### PR TITLE
operator from inputs and DSL

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,6 +70,7 @@ jobs:
          CXX=${{matrix.compiler.CXX}} \
          cmake --preset develop \
            -DNEOFOAM_DEVEL_TOOLS=OFF \
+           -DNEOFOAM_BUILD_TESTS=ON \
            -DNEOFOAM_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF
          cmake --build  --preset develop
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,7 +70,6 @@ jobs:
          CXX=${{matrix.compiler.CXX}} \
          cmake --preset develop \
            -DNEOFOAM_DEVEL_TOOLS=OFF \
-           -DNEOFOAM_BUILD_TESTS=ON \
            -DNEOFOAM_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF
          cmake --build  --preset develop
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -23,7 +23,8 @@
       "displayName": "Production",
       "description": "Configuration for production use",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release"
+        "CMAKE_BUILD_TYPE": "Release",
+        "FOAMADAPTER_BUILD_EXAMPLES": "ON"
       }
     },
     {

--- a/examples/scalarAdvection/createFields.H
+++ b/examples/scalarAdvection/createFields.H
@@ -17,7 +17,7 @@ Foam::volVectorField
       mesh);
 
 
-if (controlDict.get<bool>("setFields"))
+if (controlDict.get<int>("setFields"))
 {
     Foam::scalar spread = 0.05;
     Foam::scalar pi = Foam::constant::mathematical::pi;

--- a/examples/scalarAdvection/createFields.H
+++ b/examples/scalarAdvection/createFields.H
@@ -9,11 +9,37 @@ Foam::volScalarField
       ),
       mesh);
 
+// initilize T
+Foam::scalar spread = 0.05;
+forAll(T, celli)
+{
+    T[celli] = std::exp(
+        -0.5
+        * (std::pow((mesh.C()[celli].x() - 0.5) / spread, 2.0)
+           + std::pow((mesh.C()[celli].y() - 0.75) / spread, 2.0))
+    );
+}
+T.correctBoundaryConditions();
+T.write();
+
 Foam::volVectorField
     U(Foam::IOobject(
           "U", runTime.timeName(), mesh, Foam::IOobject::MUST_READ, Foam::IOobject::AUTO_WRITE
       ),
       mesh);
+
+// initilize U
+Foam::scalar pi = Foam::constant::mathematical::pi;
+
+forAll(U, celli)
+{
+    Foam::scalar x = mesh.C()[celli].x();
+    Foam::scalar y = mesh.C()[celli].y();
+
+    U[celli].x() = -Foam::sin(2.0 * pi * y) * Foam::pow(Foam::sin(pi * x), 2.0);
+    U[celli].y() = Foam::sin(2.0 * pi * x) * Foam::pow(Foam::sin(pi * y), 2.0);
+    U[celli].z() = 0.0;
+}
 
 Foam::surfaceScalarField phi(
     Foam::IOobject(
@@ -25,4 +51,3 @@ Foam::surfaceScalarField phi(
 // Copies of initial U and phi for use when flow is periodic
 Foam::surfaceScalarField phi0 = phi;
 Foam::volVectorField U0 = U;
-

--- a/examples/scalarAdvection/createFields.H
+++ b/examples/scalarAdvection/createFields.H
@@ -26,4 +26,3 @@ Foam::surfaceScalarField phi(
 Foam::surfaceScalarField phi0 = phi;
 Foam::volVectorField U0 = U;
 
-const Foam::dictionary& fvSolutionDict = mesh.solutionDict();

--- a/examples/scalarAdvection/createFields.H
+++ b/examples/scalarAdvection/createFields.H
@@ -9,18 +9,6 @@ Foam::volScalarField
       ),
       mesh);
 
-// initilize T
-Foam::scalar spread = 0.05;
-forAll(T, celli)
-{
-    T[celli] = std::exp(
-        -0.5
-        * (std::pow((mesh.C()[celli].x() - 0.5) / spread, 2.0)
-           + std::pow((mesh.C()[celli].y() - 0.75) / spread, 2.0))
-    );
-}
-T.correctBoundaryConditions();
-T.write();
 
 Foam::volVectorField
     U(Foam::IOobject(
@@ -28,17 +16,31 @@ Foam::volVectorField
       ),
       mesh);
 
-// initilize U
-Foam::scalar pi = Foam::constant::mathematical::pi;
 
-forAll(U, celli)
+if (controlDict.get<bool>("setFields"))
 {
-    Foam::scalar x = mesh.C()[celli].x();
-    Foam::scalar y = mesh.C()[celli].y();
+    Foam::scalar spread = 0.05;
+    Foam::scalar pi = Foam::constant::mathematical::pi;
+    forAll(U, celli)
+    {
+        // initialize U
+        Foam::scalar x = mesh.C()[celli].x();
+        Foam::scalar y = mesh.C()[celli].y();
 
-    U[celli].x() = -Foam::sin(2.0 * pi * y) * Foam::pow(Foam::sin(pi * x), 2.0);
-    U[celli].y() = Foam::sin(2.0 * pi * x) * Foam::pow(Foam::sin(pi * y), 2.0);
-    U[celli].z() = 0.0;
+        U[celli].x() = -Foam::sin(2.0 * pi * y) * Foam::pow(Foam::sin(pi * x), 2.0);
+        U[celli].y() = Foam::sin(2.0 * pi * x) * Foam::pow(Foam::sin(pi * y), 2.0);
+        U[celli].z() = 0.0;
+
+
+        // initialize T
+        T[celli] = std::exp(
+            -0.5
+            * (std::pow((mesh.C()[celli].x() - 0.5) / spread, 2.0)
+               + std::pow((mesh.C()[celli].y() - 0.75) / spread, 2.0))
+        );
+    }
+    T.correctBoundaryConditions();
+    T.write();
 }
 
 Foam::surfaceScalarField phi(

--- a/examples/scalarAdvection/scalarAdvection.cpp
+++ b/examples/scalarAdvection/scalarAdvection.cpp
@@ -72,11 +72,16 @@ int main(int argc, char* argv[])
             Foam::scalar t = runTime.time().value();
             Foam::scalar dt = runTime.deltaT().value();
 
-            U = U0 * Foam::cos(pi * (t + 0.5 * dt) / endTime);
-            phi = phi0 * Foam::cos(pi * (t + 0.5 * dt) / endTime);
+            if (controlDict.get<int>("setFields"))
+            {
+                Foam::scalar pi = Foam::constant::mathematical::pi;
+                U = U0 * Foam::cos(pi * (t + 0.5 * dt) / endTime);
+                phi = phi0 * Foam::cos(pi * (t + 0.5 * dt) / endTime);
 
-            nfPhi.internalField() =
-                nfPhi0.internalField() * std::cos(pi * (t + 0.5 * dt) / endTime);
+                nfPhi.internalField() =
+                    nfPhi0.internalField() * std::cos(pi * (t + 0.5 * dt) / endTime);
+            }
+
 
             std::tie(adjustTimeStep, maxCo, maxDeltaT) = timeControls(runTime);
             CoNum = calculateCoNum(phi);

--- a/examples/scalarAdvection/scalarAdvection.cpp
+++ b/examples/scalarAdvection/scalarAdvection.cpp
@@ -2,6 +2,14 @@
 // SPDX-FileCopyrightText: 2023 NeoFOAM authors
 
 #include "FoamAdapter/FoamAdapter.hpp"
+#include "NeoFOAM/dsl/expression.hpp"
+#include "NeoFOAM/dsl/solver.hpp"
+#include "NeoFOAM/dsl/ddt.hpp"
+#include "FoamAdapter/readers/foamDictionary.hpp"
+
+// #include "NeoFOAM/dsl/implicit.hpp"
+// #include "NeoFOAM/dsl/explicit.hpp"
+
 
 #define namespaceFoam
 #include "fvCFD.H"
@@ -11,8 +19,10 @@ using Foam::endl;
 using Foam::nl;
 namespace fvc = Foam::fvc;
 
-// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+namespace dsl = NeoFOAM::dsl;
 namespace fvcc = NeoFOAM::finiteVolume::cellCentred;
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
 int main(int argc, char* argv[])
 {
@@ -24,6 +34,8 @@ int main(int argc, char* argv[])
 #include "createNFTime.H"
 #include "createControl.H"
 #include "createFields.H"
+        NeoFOAM::Dictionary fvSchemesDict = Foam::readFoamDictionary(mesh.schemesDict());
+        NeoFOAM::Dictionary fvSolutionDict = Foam::readFoamDictionary(mesh.solutionDict());
 
         Info << "creating NeoFOAM mesh" << endl;
         auto nfMesh = mesh.nfMesh();
@@ -41,25 +53,16 @@ int main(int argc, char* argv[])
 
             Info << "Time = " << runTime.timeName() << nl << max(phi) << nl << max(U) << endl;
 
-            // NeoFOAM Euler
-            // NOTE for now hardcoded
-            // this will soon be replaced by the NeoFOAM DSL
-            {
-                fvcc::GaussGreenDiv(
-                    exec,
-                    nfMesh,
-                    fvcc::SurfaceInterpolation(
-                        exec,
-                        nfMesh,
-                        fvcc::SurfaceInterpolationFactory::create("upwind", exec, nfMesh)
-                    )
-                )
-                    .div(nfDivT, nfPhi, nfT);
 
-                nfT.internalField() =
-                    nfT.internalField() - nfDivT.internalField() * runTime.deltaT().value();
-                nfT.correctBoundaryConditions();
-                Kokkos::fence();
+
+            {
+                // dsl::Expression eqnSys(
+                //     dsl::Implicit::ddt(nfT)
+                //   + dsl::Implicit::ddt(nfT)
+                // );
+
+                // NeoFOAM::scalar dt = runTime.deltaT().value();
+                // dsl::solve(eqnSys, nfT, dt, fvSchemesDict, fvSolutionDict);
             }
 
             if (runTime.outputTime())

--- a/examples/scalarAdvection/scalarAdvection.cpp
+++ b/examples/scalarAdvection/scalarAdvection.cpp
@@ -88,6 +88,8 @@ int main(int argc, char* argv[])
             }
             runTime++;
 
+            Info << "Time = " << runTime.timeName() << endl;
+
 
             {
                 dsl::Expression eqnSys(dsl::imp::ddt(nfT) + dsl::exp::div(nfPhi, nfT));

--- a/examples/scalarAdvection/scalarAdvection.cpp
+++ b/examples/scalarAdvection/scalarAdvection.cpp
@@ -47,10 +47,10 @@ int main(int argc, char* argv[])
 
         std::tie(adjustTimeStep, maxCo, maxDeltaT) = timeControls(runTime);
 
-        Foam::scalar CoNum = Foam::calculateCoNum(phi);
+        Foam::scalar coNum = Foam::calculateCoNum(phi);
         if (adjustTimeStep)
         {
-            Foam::setDeltaT(runTime, maxCo, CoNum, maxDeltaT);
+            Foam::setDeltaT(runTime, maxCo, coNum, maxDeltaT);
         }
 
 
@@ -84,12 +84,12 @@ int main(int argc, char* argv[])
 
 
             std::tie(adjustTimeStep, maxCo, maxDeltaT) = timeControls(runTime);
-            CoNum = calculateCoNum(phi);
+            coNum = calculateCoNum(phi);
             Foam::Info << "max(phi) : " << max(phi).value() << Foam::endl;
             Foam::Info << "max(U) : " << max(U).value() << Foam::endl;
             if (adjustTimeStep)
             {
-                Foam::setDeltaT(runTime, maxCo, CoNum, maxDeltaT);
+                Foam::setDeltaT(runTime, maxCo, coNum, maxDeltaT);
             }
             runTime++;
 

--- a/examples/scalarAdvection/scalarAdvection.cpp
+++ b/examples/scalarAdvection/scalarAdvection.cpp
@@ -62,7 +62,8 @@ int main(int argc, char* argv[])
 
         Info << "creating NeoFOAM fields" << endl;
         auto nfT = Foam::constructFrom(exec, nfMesh, T);
-        auto nfPhi = Foam::constructSurfaceField(exec, nfMesh, phi0);
+        auto nfPhi0 = Foam::constructSurfaceField(exec, nfMesh, phi0);
+        auto nfPhi = Foam::constructSurfaceField(exec, nfMesh, phi);
 
         Foam::scalar endTime = controlDict.get<Foam::scalar>("endTime");
 
@@ -70,11 +71,12 @@ int main(int argc, char* argv[])
         {
             Foam::scalar t = runTime.time().value();
             Foam::scalar dt = runTime.deltaT().value();
-            nfPhi.internalField() =
-                nfPhi.internalField() * std::cos(pi * (t + 0.5 * dt) / endTime);
 
             U = U0 * Foam::cos(pi * (t + 0.5 * dt) / endTime);
             phi = phi0 * Foam::cos(pi * (t + 0.5 * dt) / endTime);
+
+            nfPhi.internalField() =
+                nfPhi0.internalField() * std::cos(pi * (t + 0.5 * dt) / endTime);
 
             std::tie(adjustTimeStep, maxCo, maxDeltaT) = timeControls(runTime);
             CoNum = calculateCoNum(phi);

--- a/include/FoamAdapter/readers.hpp
+++ b/include/FoamAdapter/readers.hpp
@@ -78,7 +78,7 @@ auto constructFrom(
     using type_container_t = typename type_map<FoamType>::container_type;
     using type_primitive_t = typename type_map<FoamType>::mapped_type;
 
-    type_container_t out(exec, nfMesh, readVolBoundaryConditions(nfMesh, in));
+    type_container_t out(exec, in.name(), nfMesh, readVolBoundaryConditions(nfMesh, in));
 
     out.internalField() = fromFoamField(exec, in.primitiveField());
     out.correctBoundaryConditions();
@@ -141,7 +141,7 @@ auto constructSurfaceField(
     using type_primitive_t = typename type_map<FoamType>::mapped_type;
     using foam_primitive_t = typename FoamType::cmptType;
 
-    type_container_t out(exec, nfMesh, std::move(readSurfaceBoundaryConditions(nfMesh, in)));
+    type_container_t out(exec, in.name(),nfMesh, std::move(readSurfaceBoundaryConditions(nfMesh, in)));
 
     Field<foam_primitive_t> flattenedField(out.internalField().size());
     size_t nInternal = nfMesh.nInternalFaces();

--- a/test/test_operators.cpp
+++ b/test/test_operators.cpp
@@ -9,6 +9,7 @@
 
 #define namespaceFoam // Suppress <using namespace Foam;>
 #include "gaussConvectionScheme.H"
+#include "NeoFOAM/core/input.hpp"
 
 #include "common.hpp"
 
@@ -52,7 +53,8 @@ TEST_CASE("Interpolation")
 
         SECTION("linear")
         {
-            auto linearKernel = fvcc::SurfaceInterpolationFactory::create("linear", exec, nfMesh);
+            NeoFOAM::Input interpolationScheme = NeoFOAM::TokenList({std::string("linear")});
+            auto linearKernel = fvcc::SurfaceInterpolationFactory::create(exec, nfMesh,interpolationScheme);
             fvcc::SurfaceInterpolation interp(exec, nfMesh, std::move(linearKernel));
             // TODO since it is constructed from ofField it is trivial
             // we should reset the field first

--- a/test/test_operators.cpp
+++ b/test/test_operators.cpp
@@ -56,7 +56,8 @@ TEST_CASE("Interpolation")
         SECTION("linear")
         {
             NeoFOAM::Input interpolationScheme = NeoFOAM::TokenList({std::string("linear")});
-            auto linearKernel = fvcc::SurfaceInterpolationFactory::create(exec, nfMesh,interpolationScheme);
+            auto linearKernel =
+                fvcc::SurfaceInterpolationFactory::create(exec, nfMesh, interpolationScheme);
             fvcc::SurfaceInterpolation interp(exec, nfMesh, std::move(linearKernel));
             // TODO since it is constructed from ofField it is trivial
             // we should reset the field first
@@ -158,21 +159,16 @@ TEST_CASE("DivOperator")
             // Reset
             NeoFOAM::fill(nfDivT.internalField(), 0.0);
             NeoFOAM::fill(nfDivT.boundaryField().value(), 0.0);
-            fvcc::GaussGreenDiv(
-                exec,
-                nfMesh,
-                scheme
-            )
-            .div(nfDivT, nfPhi, nfT);
+            fvcc::GaussGreenDiv(exec, nfMesh, scheme).div(nfDivT, nfPhi, nfT);
             nfDivT.correctBoundaryConditions();
 
             compare(nfDivT, ofDivT, ApproxScalar(1e-15), false);
-
         }
 
         SECTION("compute div from dsl::exp")
         {
-            NeoFOAM::TokenList scheme = NeoFOAM::TokenList({std::string("Gauss"), std::string("linear")});
+            NeoFOAM::TokenList scheme =
+                NeoFOAM::TokenList({std::string("Gauss"), std::string("linear")});
 
             auto nfDivT = constructFrom(exec, nfMesh, ofDivT);
             NeoFOAM::fill(nfDivT.internalField(), 0.0);

--- a/test/test_operators.cpp
+++ b/test/test_operators.cpp
@@ -10,10 +10,12 @@
 #define namespaceFoam // Suppress <using namespace Foam;>
 #include "gaussConvectionScheme.H"
 #include "NeoFOAM/core/input.hpp"
+#include "NeoFOAM/dsl/explicit.hpp"
 
 #include "common.hpp"
 
 namespace fvcc = NeoFOAM::finiteVolume::cellCentred;
+namespace dsl = NeoFOAM::dsl;
 
 extern Foam::Time* timePtr;    // A single time object
 extern Foam::argList* argsPtr; // Some forks want argList access at createMesh.H
@@ -112,8 +114,8 @@ TEST_CASE("DivOperator")
     Foam::argList& args = *argsPtr;
 
     NeoFOAM::Executor exec = GENERATE(
-        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
         NeoFOAM::Executor(NeoFOAM::SerialExecutor {}),
+        NeoFOAM::Executor(NeoFOAM::CPUExecutor {}),
         NeoFOAM::Executor(NeoFOAM::GPUExecutor {})
     );
     std::string execName = std::visit([](auto e) { return e.print(); }, exec);
@@ -149,21 +151,39 @@ TEST_CASE("DivOperator")
 
         auto nfPhi = constructSurfaceField(exec, nfMesh, ofPhi);
 
-        SECTION("Computes correct divT")
+        SECTION("Gauss-Green")
         {
             auto nfDivT = constructFrom(exec, nfMesh, ofDivT);
+            NeoFOAM::TokenList scheme({std::string("linear")});
             // Reset
             NeoFOAM::fill(nfDivT.internalField(), 0.0);
             NeoFOAM::fill(nfDivT.boundaryField().value(), 0.0);
             fvcc::GaussGreenDiv(
                 exec,
                 nfMesh,
-                fvcc::SurfaceInterpolation(
-                    exec, nfMesh, std::make_unique<fvcc::Linear>(exec, nfMesh)
-                )
+                scheme
             )
-                .div(nfDivT, nfPhi, nfT);
+            .div(nfDivT, nfPhi, nfT);
             nfDivT.correctBoundaryConditions();
+
+            compare(nfDivT, ofDivT, ApproxScalar(1e-15), false);
+
+        }
+
+        SECTION("compute div from dsl::exp")
+        {
+            NeoFOAM::TokenList scheme = NeoFOAM::TokenList({std::string("Gauss"), std::string("linear")});
+
+            auto nfDivT = constructFrom(exec, nfMesh, ofDivT);
+            NeoFOAM::fill(nfDivT.internalField(), 0.0);
+            NeoFOAM::fill(nfDivT.boundaryField().value(), 0.0);
+            dsl::Operator divOp = dsl::exp::div(nfPhi, nfT);
+            divOp.build(scheme);
+            divOp.explicitOperation(nfDivT.internalField());
+
+            nfDivT.correctBoundaryConditions();
+
+            compare(nfT, ofT, ApproxScalar(1e-15), false);
 
             compare(nfDivT, ofDivT, ApproxScalar(1e-15), false);
         }

--- a/tutorials/scalarAdvection/system/controlDict
+++ b/tutorials/scalarAdvection/system/controlDict
@@ -52,6 +52,8 @@ maxCo           0.1;
 
 maxDeltaT       1;
 
+setFields       1;
+
 profiling
 {
     active      true;

--- a/tutorials/scalarAdvection/system/controlDict
+++ b/tutorials/scalarAdvection/system/controlDict
@@ -24,7 +24,7 @@ startTime       0;
 
 stopAt          endTime;
 
-endTime         3;
+endTime         3.0;
 
 deltaT          0.005;
 
@@ -42,7 +42,7 @@ writeCompression off;
 
 timeFormat      general;
 
-timePrecision   16;
+timePrecision   8;
 
 runTimeModifiable true;
 

--- a/tutorials/scalarAdvection/system/fvSchemes
+++ b/tutorials/scalarAdvection/system/fvSchemes
@@ -22,6 +22,7 @@ ddtSchemes
     ddt(T)          Euler;
     ddt(rho,U)      Euler;
     ddt(rho,T)      Euler;
+    type            forwardEuler;
 }
 
 gradSchemes

--- a/tutorials/scalarAdvection/system/fvSolution
+++ b/tutorials/scalarAdvection/system/fvSolution
@@ -16,21 +16,9 @@ FoamFile
 
 solvers
 {
-    T
-    {
-        solver          PCG;
-        preconditioner  DIC;
-        tolerance       1e-06;
-        relTol          0;
-    }
+
 }
 
-spirallingFlow 3;
-
-SIMPLE
-{
-    nNonOrthogonalCorrectors 2;
-}
 
 
 // ************************************************************************* //

--- a/tutorials/scalarAdvection/system/simulationParameters
+++ b/tutorials/scalarAdvection/system/simulationParameters
@@ -14,7 +14,7 @@ FoamFile
     object          simulationParameters;
 }
 
-NX              100;
+NX              200;
 
 
 


### PR DESCRIPTION

* read operators from Foam dictionaries

```
divSchemes
{
    default         none;
    div(phi,T)          Gauss upwind;
    div(neoPhi,neoT)    Gauss upwind;
}
```
*dsl implementation
```
      dsl::EqnSystem<NeoFOAM::scalar> eqnSys(
          fvcc::impOp::ddt(neoT)
        + fvcc::expOp::div(neoPhi, neoT)
      );
      eqnSys.dt = runTime.deltaT().value();
      eqnSys.fvSchemesDict = fvSchemesDict;

      eqnSys.solve();
```