### PR TITLE
Benchmark/scalar advection

### DIFF
--- a/examples/scalarAdvection/CMakeLists.txt
+++ b/examples/scalarAdvection/CMakeLists.txt
@@ -9,3 +9,7 @@ target_link_libraries(scalarAdvection FoamAdapter)
 add_executable(scalarFoamAdvection scalarFoamAdvection.cpp)
 
 target_link_libraries(scalarFoamAdvection FoamAdapter)
+
+add_executable(scalarNeoFoamAdvection scalarNeoFoamAdvection.cpp)
+
+target_link_libraries(scalarNeoFoamAdvection FoamAdapter)

--- a/examples/scalarAdvection/CMakeLists.txt
+++ b/examples/scalarAdvection/CMakeLists.txt
@@ -5,3 +5,7 @@
 add_executable(scalarAdvection scalarAdvection.cpp)
 
 target_link_libraries(scalarAdvection FoamAdapter)
+
+add_executable(scalarFoamAdvection scalarFoamAdvection.cpp)
+
+target_link_libraries(scalarFoamAdvection FoamAdapter)

--- a/examples/scalarAdvection/createFields.H
+++ b/examples/scalarAdvection/createFields.H
@@ -25,31 +25,27 @@ Foam::volVectorField
       mesh);
 
 
-if (controlDict.get<int>("setFields"))
+Foam::scalar spread = 0.05;
+Foam::scalar pi = Foam::constant::mathematical::pi;
+forAll(U, celli)
 {
-    Foam::scalar spread = 0.05;
-    Foam::scalar pi = Foam::constant::mathematical::pi;
-    forAll(U, celli)
-    {
-        // initialize U
-        Foam::scalar x = mesh.C()[celli].x();
-        Foam::scalar y = mesh.C()[celli].y();
+    // initialize U
+    Foam::scalar x = mesh.C()[celli].x();
+    Foam::scalar y = mesh.C()[celli].y();
 
-        U[celli].x() = -Foam::sin(2.0 * pi * y) * Foam::pow(Foam::sin(pi * x), 2.0);
-        U[celli].y() = Foam::sin(2.0 * pi * x) * Foam::pow(Foam::sin(pi * y), 2.0);
-        U[celli].z() = 0.0;
+    U[celli].x() = -Foam::sin(2.0 * pi * y) * Foam::pow(Foam::sin(pi * x), 2.0);
+    U[celli].y() = Foam::sin(2.0 * pi * x) * Foam::pow(Foam::sin(pi * y), 2.0);
+    U[celli].z() = 0.0;
 
 
-        // initialize T
-        T[celli] = std::exp(
-            -0.5
-            * (std::pow((mesh.C()[celli].x() - 0.5) / spread, 2.0)
-               + std::pow((mesh.C()[celli].y() - 0.75) / spread, 2.0))
-        );
-    }
-    T.correctBoundaryConditions();
-    T.write();
+    // initialize T
+    T[celli] = std::exp(
+        -0.5
+        * (std::pow((mesh.C()[celli].x() - 0.5) / spread, 2.0)
+           + std::pow((mesh.C()[celli].y() - 0.75) / spread, 2.0))
+    );
 }
+T.correctBoundaryConditions();
 
 Foam::surfaceScalarField
     phi(Foam::IOobject(

--- a/examples/scalarAdvection/scalarAdvection.cpp
+++ b/examples/scalarAdvection/scalarAdvection.cpp
@@ -39,7 +39,7 @@ int main(int argc, char* argv[])
 
 
         NeoFOAM::Dictionary controlDict = Foam::readFoamDictionary(runTime.controlDict());
-        NeoFOAM::Executor exec = createExecutor(runTime.controlDict());
+        NeoFOAM::Executor exec = Foam::createExecutor(runTime.controlDict());
 
         std::unique_ptr<Foam::MeshAdapter> meshPtr = Foam::createMesh(exec, runTime);
         Foam::MeshAdapter& mesh = *meshPtr;

--- a/examples/scalarAdvection/scalarFoamAdvection.cpp
+++ b/examples/scalarAdvection/scalarFoamAdvection.cpp
@@ -78,9 +78,12 @@ int main(int argc, char* argv[])
         // Info << "max(U) : " << max(U).value() << endl;
 
         // advance Foam fields in time
-        Foam::fvScalarMatrix TEqn(fvm::ddt(T) + fvc::div(phi, T));
+        {
+            addProfiling(solveT, "solveT");
+            Foam::fvScalarMatrix TEqn(fvm::ddt(T) + fvc::div(phi, T));
 
-        TEqn.solve();
+            TEqn.solve();
+        }
 
         if (runTime.outputTime())
         {

--- a/examples/scalarAdvection/scalarFoamAdvection.cpp
+++ b/examples/scalarAdvection/scalarFoamAdvection.cpp
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2023 NeoFOAM authors
+
+#include "FoamAdapter/FoamAdapter.hpp"
+#include "NeoFOAM/dsl/expression.hpp"
+#include "NeoFOAM/dsl/solver.hpp"
+#include "NeoFOAM/dsl/ddt.hpp"
+#include "FoamAdapter/readers/foamDictionary.hpp"
+
+#include "NeoFOAM/dsl/implicit.hpp"
+#include "NeoFOAM/dsl/explicit.hpp"
+
+
+#define namespaceFoam
+#include "fvCFD.H"
+
+using Foam::Info;
+using Foam::endl;
+using Foam::nl;
+namespace fvc = Foam::fvc;
+namespace fvm = Foam::fvm;
+
+namespace dsl = NeoFOAM::dsl;
+namespace fvcc = NeoFOAM::finiteVolume::cellCentred;
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+int main(int argc, char* argv[])
+{
+
+#include "addCheckCaseOptions.H"
+#include "setRootCase.H"
+#include "createTime.H"
+    // #include "createMesh.H" requires using Foam which is incompatible with NVCC
+
+    std::unique_ptr<Foam::fvMesh> meshPtr = Foam::createMesh(runTime);
+    Foam::fvMesh& mesh = *meshPtr;
+
+#include "createControl.H"
+
+    auto [adjustTimeStep, maxCo, maxDeltaT] = Foam::timeControls(runTime);
+
+#include "createFields.H"
+
+    std::tie(adjustTimeStep, maxCo, maxDeltaT) = timeControls(runTime);
+
+    Foam::scalar coNum = Foam::calculateCoNum(phi);
+    if (adjustTimeStep)
+    {
+        Foam::setDeltaT(runTime, maxCo, coNum, maxDeltaT);
+    }
+
+    Info << "\nStarting time loop\n" << endl;
+
+    auto endTime = runTime.endTime().value();
+
+    while (runTime.run())
+    {
+        std::tie(adjustTimeStep, maxCo, maxDeltaT) = timeControls(runTime);
+        coNum = calculateCoNum(phi);
+
+        if (adjustTimeStep)
+        {
+            Foam::setDeltaT(runTime, maxCo, coNum, maxDeltaT);
+        }
+
+        runTime++;
+        Info << "Time = " << runTime.timeName() << endl;
+
+        Foam::scalar t = runTime.time().value();
+        Foam::scalar dt = runTime.deltaT().value();
+
+        Foam::scalar pi = Foam::constant::mathematical::pi;
+        U = U0 * Foam::cos(pi * (t + 0.5 * dt) / endTime);
+        phi = phi0 * Foam::cos(pi * (t + 0.5 * dt) / endTime);
+
+        Info << "max(phi) : " << max(phi).value() << endl;
+        Info << "max(U) : " << max(U).value() << endl;
+
+        // advance Foam fields in time
+        Foam::fvScalarMatrix TEqn(fvm::ddt(T) + fvc::div(phi, T));
+
+        TEqn.solve();
+
+
+        runTime.write();
+        runTime.printExecutionTime(Info);
+    }
+
+    Info << "End\n" << endl;
+
+
+    return 0;
+}
+
+// ************************************************************************* //

--- a/examples/scalarAdvection/scalarFoamAdvection.cpp
+++ b/examples/scalarAdvection/scalarFoamAdvection.cpp
@@ -57,12 +57,7 @@ int main(int argc, char* argv[])
     while (runTime.run())
     {
         std::tie(adjustTimeStep, maxCo, maxDeltaT) = timeControls(runTime);
-        coNum = calculateCoNum(phi);
 
-        if (adjustTimeStep)
-        {
-            Foam::setDeltaT(runTime, maxCo, coNum, maxDeltaT);
-        }
 
         runTime++;
         Info << "Time = " << runTime.timeName() << endl;
@@ -71,16 +66,26 @@ int main(int argc, char* argv[])
         Foam::scalar dt = runTime.deltaT().value();
 
         Foam::scalar pi = Foam::constant::mathematical::pi;
-        U = U0 * Foam::cos(pi * (t + 0.5 * dt) / endTime);
         phi = phi0 * Foam::cos(pi * (t + 0.5 * dt) / endTime);
 
-        Info << "max(phi) : " << max(phi).value() << endl;
-        Info << "max(U) : " << max(U).value() << endl;
+        if (adjustTimeStep)
+        {
+            coNum = calculateCoNum(phi);
+            Foam::setDeltaT(runTime, maxCo, coNum, maxDeltaT);
+        }
+
+        // Info << "max(phi) : " << max(phi).value() << endl;
+        // Info << "max(U) : " << max(U).value() << endl;
 
         // advance Foam fields in time
         Foam::fvScalarMatrix TEqn(fvm::ddt(T) + fvc::div(phi, T));
 
         TEqn.solve();
+
+        if (runTime.outputTime())
+        {
+            U = U0 * Foam::cos(pi * (t + 0.5 * dt) / endTime);
+        }
 
 
         runTime.write();

--- a/examples/scalarAdvection/scalarNeoFoamAdvection.cpp
+++ b/examples/scalarAdvection/scalarNeoFoamAdvection.cpp
@@ -111,6 +111,7 @@ int main(int argc, char* argv[])
             Info << "Time = " << runTime.timeName() << endl;
 
             {
+                addProfiling(solveT, "solveT");
                 dsl::Expression eqnSys(dsl::imp::ddt(nfT) + dsl::exp::div(nfPhi, nfT));
 
                 dsl::solve(eqnSys, nfT, t, dt, fvSchemesDict, fvSolutionDict);

--- a/examples/scalarAdvection/scalarNeoFoamAdvection.cpp
+++ b/examples/scalarAdvection/scalarNeoFoamAdvection.cpp
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2023 NeoFOAM authors
+
+#include "FoamAdapter/FoamAdapter.hpp"
+#include "NeoFOAM/dsl/expression.hpp"
+#include "NeoFOAM/dsl/solver.hpp"
+#include "NeoFOAM/dsl/ddt.hpp"
+#include "FoamAdapter/readers/foamDictionary.hpp"
+
+#include "NeoFOAM/dsl/implicit.hpp"
+#include "NeoFOAM/dsl/explicit.hpp"
+
+
+#define namespaceFoam
+#include "fvCFD.H"
+
+using Foam::Info;
+using Foam::endl;
+using Foam::nl;
+namespace fvc = Foam::fvc;
+namespace fvm = Foam::fvm;
+
+namespace dsl = NeoFOAM::dsl;
+namespace fvcc = NeoFOAM::finiteVolume::cellCentred;
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+int main(int argc, char* argv[])
+{
+
+#include "addCheckCaseOptions.H"
+#include "setRootCase.H"
+#include "createTime.H"
+    // #include "createMesh.H" requires using Foam which is incompatible with NVCC
+
+    std::unique_ptr<Foam::fvMesh> meshPtr = Foam::createMesh(runTime);
+    Foam::fvMesh& mesh = *meshPtr;
+
+#include "createControl.H"
+
+    auto [adjustTimeStep, maxCo, maxDeltaT] = Foam::timeControls(runTime);
+
+#include "createFields.H"
+
+    std::tie(adjustTimeStep, maxCo, maxDeltaT) = timeControls(runTime);
+
+    Foam::scalar coNum = Foam::calculateCoNum(phi);
+    if (adjustTimeStep)
+    {
+        Foam::setDeltaT(runTime, maxCo, coNum, maxDeltaT);
+    }
+
+    Info << "\nStarting time loop\n" << endl;
+
+    auto endTime = runTime.endTime().value();
+
+    while (runTime.run())
+    {
+        std::tie(adjustTimeStep, maxCo, maxDeltaT) = timeControls(runTime);
+        coNum = calculateCoNum(phi);
+
+        if (adjustTimeStep)
+        {
+            Foam::setDeltaT(runTime, maxCo, coNum, maxDeltaT);
+        }
+
+        runTime++;
+        Info << "Time = " << runTime.timeName() << endl;
+
+        Foam::scalar t = runTime.time().value();
+        Foam::scalar dt = runTime.deltaT().value();
+
+        Foam::scalar pi = Foam::constant::mathematical::pi;
+        U = U0 * Foam::cos(pi * (t + 0.5 * dt) / endTime);
+        phi = phi0 * Foam::cos(pi * (t + 0.5 * dt) / endTime);
+
+        Info << "max(phi) : " << max(phi).value() << endl;
+        Info << "max(U) : " << max(U).value() << endl;
+
+        // advance Foam fields in time
+        Foam::fvScalarMatrix TEqn(fvm::ddt(T) + fvc::div(phi, T));
+
+        TEqn.solve();
+
+
+        runTime.write();
+        runTime.printExecutionTime(Info);
+    }
+
+    Info << "End\n" << endl;
+
+
+    return 0;
+}
+
+// ************************************************************************* //

--- a/examples/scalarAdvection/scalarNeoFoamAdvection.cpp
+++ b/examples/scalarAdvection/scalarNeoFoamAdvection.cpp
@@ -18,7 +18,6 @@ using Foam::Info;
 using Foam::endl;
 using Foam::nl;
 namespace fvc = Foam::fvc;
-namespace fvm = Foam::fvm;
 
 namespace dsl = NeoFOAM::dsl;
 namespace fvcc = NeoFOAM::finiteVolume::cellCentred;
@@ -27,68 +26,111 @@ namespace fvcc = NeoFOAM::finiteVolume::cellCentred;
 
 int main(int argc, char* argv[])
 {
-
+    Kokkos::initialize(argc, argv);
+    {
 #include "addCheckCaseOptions.H"
 #include "setRootCase.H"
 #include "createTime.H"
-    // #include "createMesh.H" requires using Foam which is incompatible with NVCC
 
-    std::unique_ptr<Foam::fvMesh> meshPtr = Foam::createMesh(runTime);
-    Foam::fvMesh& mesh = *meshPtr;
+        NeoFOAM::Database db;
+
+        fvcc::FieldCollection& fieldCollection =
+            fvcc::FieldCollection::instance(db, "fieldCollection");
+
+
+        NeoFOAM::Dictionary controlDict = Foam::readFoamDictionary(runTime.controlDict());
+        NeoFOAM::Executor exec = Foam::createExecutor(runTime.controlDict());
+
+        std::unique_ptr<Foam::MeshAdapter> meshPtr = Foam::createMesh(exec, runTime);
+        Foam::MeshAdapter& mesh = *meshPtr;
 
 #include "createControl.H"
 
-    auto [adjustTimeStep, maxCo, maxDeltaT] = Foam::timeControls(runTime);
+        auto [adjustTimeStep, maxCo, maxDeltaT] = Foam::timeControls(runTime);
 
 #include "createFields.H"
 
-    std::tie(adjustTimeStep, maxCo, maxDeltaT) = timeControls(runTime);
 
-    Foam::scalar coNum = Foam::calculateCoNum(phi);
-    if (adjustTimeStep)
-    {
-        Foam::setDeltaT(runTime, maxCo, coNum, maxDeltaT);
-    }
-
-    Info << "\nStarting time loop\n" << endl;
-
-    auto endTime = runTime.endTime().value();
-
-    while (runTime.run())
-    {
         std::tie(adjustTimeStep, maxCo, maxDeltaT) = timeControls(runTime);
-        coNum = calculateCoNum(phi);
 
+        Foam::scalar coNum = Foam::calculateCoNum(phi);
         if (adjustTimeStep)
         {
             Foam::setDeltaT(runTime, maxCo, coNum, maxDeltaT);
         }
 
-        runTime++;
-        Info << "Time = " << runTime.timeName() << endl;
 
-        Foam::scalar t = runTime.time().value();
-        Foam::scalar dt = runTime.deltaT().value();
+        NeoFOAM::Dictionary fvSchemesDict = Foam::readFoamDictionary(mesh.schemesDict());
+        NeoFOAM::Dictionary fvSolutionDict = Foam::readFoamDictionary(mesh.solutionDict());
 
-        Foam::scalar pi = Foam::constant::mathematical::pi;
-        U = U0 * Foam::cos(pi * (t + 0.5 * dt) / endTime);
-        phi = phi0 * Foam::cos(pi * (t + 0.5 * dt) / endTime);
+        Info << "creating NeoFOAM mesh" << endl;
+        NeoFOAM::UnstructuredMesh& nfMesh = mesh.nfMesh();
 
-        Info << "max(phi) : " << max(phi).value() << endl;
-        Info << "max(U) : " << max(U).value() << endl;
+        Info << "creating NeoFOAM fields" << endl;
+        fvcc::VolumeField<NeoFOAM::scalar>& nfT =
+            fieldCollection.registerField<fvcc::VolumeField<NeoFOAM::scalar>>(
+                Foam::CreateFromFoamField<Foam::volScalarField> {
+                    .exec = exec,
+                    .nfMesh = nfMesh,
+                    .foamField = T,
+                    .name = "nfT"
+                }
+            );
+        auto nfPhi0 = Foam::constructSurfaceField(exec, nfMesh, phi0);
+        auto nfPhi = Foam::constructSurfaceField(exec, nfMesh, phi);
 
-        // advance Foam fields in time
-        Foam::fvScalarMatrix TEqn(fvm::ddt(T) + fvc::div(phi, T));
+        auto [sPhi, sPhi0] = NeoFOAM::spans(nfPhi.internalField(), nfPhi0.internalField());
 
-        TEqn.solve();
+        Foam::scalar endTime = controlDict.get<Foam::scalar>("endTime");
+
+        while (runTime.run())
+        {
+            Foam::scalar t = runTime.time().value();
+            Foam::scalar dt = runTime.deltaT().value();
 
 
-        runTime.write();
-        runTime.printExecutionTime(Info);
+            Foam::scalar pi = Foam::constant::mathematical::pi;
+            NeoFOAM::scalar scale = std::cos(pi * (t + 0.5 * dt) / endTime);
+            NeoFOAM::map(
+                nfPhi.internalField(),
+                KOKKOS_LAMBDA(const int i) { return sPhi0[i] * scale; }
+            );
+
+            std::tie(adjustTimeStep, maxCo, maxDeltaT) = timeControls(runTime);
+
+            // Foam::Info << "max(phi) : " << max(phi).value() << Foam::endl;
+            // Foam::Info << "max(U) : " << max(U).value() << Foam::endl;
+            if (adjustTimeStep)
+            {
+                phi = phi0 * Foam::cos(pi * (t + 0.5 * dt) / endTime);
+                coNum = calculateCoNum(phi);
+                Foam::setDeltaT(runTime, maxCo, coNum, maxDeltaT);
+            }
+            runTime++;
+
+            Info << "Time = " << runTime.timeName() << endl;
+
+            {
+                dsl::Expression eqnSys(dsl::imp::ddt(nfT) + dsl::exp::div(nfPhi, nfT));
+
+                dsl::solve(eqnSys, nfT, t, dt, fvSchemesDict, fvSolutionDict);
+            }
+
+            if (runTime.outputTime())
+            {
+                U = U0 * Foam::cos(pi * (t + 0.5 * dt) / endTime);
+                phi = phi0 * Foam::cos(pi * (t + 0.5 * dt) / endTime);
+                Info << "writing nfT field" << endl;
+                write(nfT.internalField(), mesh, "nfT");
+            }
+
+            runTime.write();
+            runTime.printExecutionTime(Info);
+        }
+
+        Info << "End\n" << endl;
     }
-
-    Info << "End\n" << endl;
-
+    Kokkos::finalize();
 
     return 0;
 }

--- a/tutorials/scalarAdvection/Allrun
+++ b/tutorials/scalarAdvection/Allrun
@@ -10,7 +10,18 @@ mesh=$2
 
 runApplication blockMesh
 
-time ../../build/profiling/bin/scalarNeoFoamAdvection  > log.scalarNeoFoamAdvection
-time ../../build/profiling/bin/scalarFoamAdvection > log.scalarFoamAdvection
+foamDictionary system/controlDict -entry executor -set GPU
+time ../../build/production/bin/scalarNeoFoamAdvection  > log.scalarNeoFoamAdvectionGPU
+
+foamDictionary system/controlDict -entry executor -set CPU
+time ../../build/production/bin/scalarNeoFoamAdvection  > log.scalarNeoFoamAdvectionCPU
+
+foamDictionary system/controlDict -entry executor -set Serial
+time ../../build/production/bin/scalarNeoFoamAdvection  > log.scalarNeoFoamAdvectionSerial
+
+time ../../build/production/bin/scalarFoamAdvection > log.scalarFoamAdvectionSerial
+
+runApplication decomposePar
+runParallel ../../build/production/bin/scalarFoamAdvection
 
 #------------------------------------------------------------------------------

--- a/tutorials/scalarAdvection/Allrun
+++ b/tutorials/scalarAdvection/Allrun
@@ -10,6 +10,7 @@ mesh=$2
 
 runApplication blockMesh
 
-runApplication ../../build/profiling/bin/scalarAdvection
+time ../../build/profiling/bin/scalarNeoFoamAdvection  > log.scalarNeoFoamAdvection
+time ../../build/profiling/bin/scalarFoamAdvection > log.scalarFoamAdvection
 
 #------------------------------------------------------------------------------

--- a/tutorials/scalarAdvection/system/controlDict
+++ b/tutorials/scalarAdvection/system/controlDict
@@ -26,17 +26,17 @@ stopAt          endTime;
 
 endTime         3.0;
 
-deltaT          0.005;
+deltaT          0.0001;
 
 writeControl    adjustable;
 
-writeInterval   0.1;
+writeInterval   5.0;
 
 purgeWrite      0;
 
 writeFormat     ascii;
 
-writePrecision  16;
+writePrecision  8;
 
 writeCompression off;
 
@@ -46,11 +46,11 @@ timePrecision   8;
 
 runTimeModifiable true;
 
-adjustTimeStep  yes;
+adjustTimeStep  no;
 
 maxCo           0.1;
 
-maxDeltaT       1;
+maxDeltaT       0.0001;
 
 setFields       1;
 

--- a/tutorials/scalarAdvection/system/controlDict
+++ b/tutorials/scalarAdvection/system/controlDict
@@ -1,18 +1,18 @@
 /*--------------------------------*- C++ -*----------------------------------*\
 | =========                 |                                                 |
 | \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \\    /   O peration     | Version:  v2306                                 |
+|  \\    /   O peration     | Version:  2406                                  |
 |   \\  /    A nd           | Website:  www.openfoam.com                      |
 |    \\/     M anipulation  |                                                 |
 \*---------------------------------------------------------------------------*/
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 FoamFile
 {
-    version     2.0;
-    format      ascii;
-    class       dictionary;
-    object      controlDict;
+    version         2;
+    format          ascii;
+    class           dictionary;
+    object          controlDict;
 }
-// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
 application     scalarAdvection;
 
@@ -24,13 +24,13 @@ startTime       0;
 
 stopAt          endTime;
 
-endTime         3.0;
+endTime         2.9999;
 
 deltaT          0.0001;
 
 writeControl    adjustable;
 
-writeInterval   5.0;
+writeInterval   3;
 
 purgeWrite      0;
 
@@ -56,9 +56,11 @@ setFields       1;
 
 profiling
 {
-    active      true;
-    cpuInfo     true;
-    memInfo     true;
-    sysInfo     true;
+    active          true;
+    cpuInfo         true;
+    memInfo         true;
+    sysInfo         true;
 }
+
+
 // ************************************************************************* //

--- a/tutorials/scalarAdvection/system/decomposeParDict
+++ b/tutorials/scalarAdvection/system/decomposeParDict
@@ -14,7 +14,7 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-numberOfSubdomains 4;
+numberOfSubdomains 8;
 
 method          scotch;
 

--- a/tutorials/scalarAdvection/system/fvSchemes
+++ b/tutorials/scalarAdvection/system/fvSchemes
@@ -22,9 +22,9 @@ ddtSchemes
     ddt(T)          Euler;
     ddt(rho,U)      Euler;
     ddt(rho,T)      Euler;
-    //type            forwardEuler;
-    type            Runge-Kutta;
-    Runge-Kutta-Method Forward-Euler;
+    type            forwardEuler;
+    //type            Runge-Kutta;
+    //Runge-Kutta-Method Forward-Euler;
 }
 
 gradSchemes

--- a/tutorials/scalarAdvection/system/fvSolution
+++ b/tutorials/scalarAdvection/system/fvSolution
@@ -16,7 +16,14 @@ FoamFile
 
 solvers
 {
-
+    T
+    {
+        solver diagonal;
+        //solver          PCG;
+        preconditioner  DIC;
+        tolerance       1e-06;
+        relTol          0;
+    }
 }
 
 

--- a/tutorials/scalarAdvection/system/simulationParameters
+++ b/tutorials/scalarAdvection/system/simulationParameters
@@ -14,7 +14,7 @@ FoamFile
     object          simulationParameters;
 }
 
-NX              200;
+NX              500;
 
 
 


### PR DESCRIPTION
Adds to new example scalarFoamAdvection and scalarNeoFoamAdvection

and a very unsophisticated benchmark for discussion and to try it out

The goal of NeoFOAM is to reduce the clockTime of solvers while ensuring the same results. The implementation of a Foam and NeoFOAM version side by side would enables us to understand the performance impact and also guides a way to a clean syntax

Features:

* the CFL number is always on the CPU (preliminary solution turn it off)
* 

This benchmarking is quite tedious and should be automated  with snakemake to do quick parameter scans.

What are your thoughts about a benchmarking with this approach and automating the process as soon as possible?


@gregorweiss @greole @bevanwsjones 

Note: The Serial and the OpenFOAM implementation of NeoFOAM show a similar performance
