### PR TITLE
Make the tutorial case run successfully

### DIFF
--- a/tutorials/scalarAdvection/system/controlDict
+++ b/tutorials/scalarAdvection/system/controlDict
@@ -28,9 +28,9 @@ endTime         3.0;
 
 deltaT          0.005;
 
-writeControl    adjustable;
+writeControl    none; // adjustable
 
-writeInterval   0.1;
+writeInterval   3.0; // dont write
 
 purgeWrite      0;
 

--- a/tutorials/scalarAdvection/system/fvSolution
+++ b/tutorials/scalarAdvection/system/fvSolution
@@ -16,7 +16,13 @@ FoamFile
 
 solvers
 {
-
+    T
+    {
+        solver          diagonal;
+        /* preconditioner  DIC;
+        tolerance       1e-06;
+        relTol          0; */
+    }
 }
 
 

--- a/tutorials/scalarAdvection/system/simulationParameters
+++ b/tutorials/scalarAdvection/system/simulationParameters
@@ -14,7 +14,7 @@ FoamFile
     object          simulationParameters;
 }
 
-NX              200;
+NX              50;
 
 
 


### PR DESCRIPTION
The tutorial case failed to finish, but the advection for testing can run successfully.
Replacing the system directory of the tutorial case with the system directory of the advection for testing fixed the issue.