### PR TITLE
use new CFL implementation

### DIFF
--- a/examples/icoNeoFoam/icoNeoFoam.cpp
+++ b/examples/icoNeoFoam/icoNeoFoam.cpp
@@ -102,19 +102,19 @@ int main(int argc, char* argv[])
 
         while (runTime.loop())
         {
+            Foam::scalar t = runTime.time().value();
+            Foam::scalar dt = runTime.deltaT().value();
+
             auto& nfOldU = fvcc::oldTime(nfU);
             nfOldU.internalField() = nfU.internalField();
             std::tie(adjustTimeStep, maxCo, maxDeltaT) = timeControls(runTime);
-            coNum = computeCoNum(phi);
+            coNum = fvcc::computeCoNum(nfPhi, dt);
             Foam::Info << "max(phi) : " << max(phi).value() << Foam::endl;
             Foam::Info << "max(U) : " << max(U).value() << Foam::endl;
             if (adjustTimeStep)
             {
                 Foam::setDeltaT(runTime, maxCo, coNum, maxDeltaT);
             }
-
-            Foam::scalar t = runTime.time().value();
-            Foam::scalar dt = runTime.deltaT().value();
 
             Info << "Time = " << runTime.timeName() << nl << endl;
 

--- a/examples/icoNeoFoam/icoNeoFoam.cpp
+++ b/examples/icoNeoFoam/icoNeoFoam.cpp
@@ -105,7 +105,7 @@ int main(int argc, char* argv[])
             auto& nfOldU = fvcc::oldTime(nfU);
             nfOldU.internalField() = nfU.internalField();
             std::tie(adjustTimeStep, maxCo, maxDeltaT) = timeControls(runTime);
-            coNum = calculateCoNum(phi);
+            coNum = computeCoNum(phi);
             Foam::Info << "max(phi) : " << max(phi).value() << Foam::endl;
             Foam::Info << "max(U) : " << max(U).value() << Foam::endl;
             if (adjustTimeStep)

--- a/examples/scalarAdvection/scalarAdvection.cpp
+++ b/examples/scalarAdvection/scalarAdvection.cpp
@@ -93,7 +93,7 @@ int main(int argc, char* argv[])
 
 
             std::tie(adjustTimeStep, maxCo, maxDeltaT) = timeControls(runTime);
-            coNum = calculateCoNum(phi);
+            coNum = computeCoNum(nfPhi, dt);
             Foam::Info << "max(phi) : " << max(phi).value() << Foam::endl;
             Foam::Info << "max(U) : " << max(U).value() << Foam::endl;
             if (adjustTimeStep)

--- a/examples/scalarAdvection/scalarAdvection.cpp
+++ b/examples/scalarAdvection/scalarAdvection.cpp
@@ -93,7 +93,7 @@ int main(int argc, char* argv[])
 
 
             std::tie(adjustTimeStep, maxCo, maxDeltaT) = timeControls(runTime);
-            coNum = computeCoNum(nfPhi, dt);
+            coNum = fvcc::computeCoNum(nfPhi, dt);
             Foam::Info << "max(phi) : " << max(phi).value() << Foam::endl;
             Foam::Info << "max(U) : " << max(U).value() << Foam::endl;
             if (adjustTimeStep)


### PR DESCRIPTION
Left over from Hackathon.

Using the CFL implementation in the application loops. 

Gives >30% performance gain in scalarAdvection.