### PR TITLE
Fetch Catch2 and make it available to benchmarks

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,10 +1,24 @@
 # SPDX-License-Identifier: Unlicense
 # SPDX-FileCopyrightText: 2023-25 NeoN authors
 
+include(FetchContent)
+
+FetchContent_Declare(
+  Catch2
+  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+  GIT_TAG v3.4.0   
+)
+FetchContent_MakeAvailable(Catch2)
+
 function(NeoN_benchmark BENCH)
 
   add_executable(bench_${BENCH} "bench_${BENCH}.cpp")
-  target_link_libraries(bench_${BENCH} PRIVATE Catch2::Catch2 OpenFOAM FoamAdapter)
+  target_link_libraries(bench_${BENCH}
+    PRIVATE
+      Catch2::Catch2
+      OpenFOAM
+      FoamAdapter
+  )
   target_include_directories(bench_${BENCH} PRIVATE "${CMAKE_SOURCE_DIR}")
 
   if(WIN32)


### PR DESCRIPTION
The config step fails for the CMake preset `profiling` because Catch2 cannot be found for linking targets in benchmarks directory.