### PR TITLE
Add a CI job which is triggered by NeoN CI pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -100,7 +100,7 @@ build-and-test-foamadapter:
 build-and-test-foamadapter-triggered:
   <<: *build-foamadapter-common
   rules:
-    # Run only if NeoN pipeline triggered this one
+    # Run only if NeoN pipeline triggered this one (the variables are passed from NeoN pipeline)
     - if: '$NEON_COMMIT || $NEON_BRANCH'
       when: always
 


### PR DESCRIPTION
A CI job is added to check if the changes in NeoN work for FoamAdapter. It is set up to be triggered by NeoN CI pipeline.