### PR TITLE
Skip changelog check job for a PR whenever skip-changelog label is present

### DIFF
--- a/.github/workflows/changelog_check.yaml
+++ b/.github/workflows/changelog_check.yaml
@@ -1,0 +1,17 @@
+name: Changelog check
+run-name: Changelog check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  changelog:
+    name: Changelog check
+    runs-on: ubuntu-24.04
+    if: !contains(toJson(github.event.pull_request.labels.*.name), 'skip-changelog')
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dangoslen/changelog-enforcer@v3
+        with:
+          changeLogPath: CHANGELOG.md

--- a/.github/workflows/changelog_check.yaml
+++ b/.github/workflows/changelog_check.yaml
@@ -9,7 +9,7 @@ jobs:
   changelog:
     name: Changelog check
     runs-on: ubuntu-24.04
-    if: !contains(toJson(github.event.pull_request.labels.*.name), 'skip-changelog')
+    if: "!contains(toJson(github.event.pull_request.labels.*.name), 'skip-changelog')"
     steps:
       - uses: actions/checkout@v4
       - uses: dangoslen/changelog-enforcer@v3

--- a/.github/workflows/static_checks.yaml
+++ b/.github/workflows/static_checks.yaml
@@ -2,8 +2,9 @@ name: Static checks
 run-name: Static checks
 
 on:
-    pull_request:
-      types: [opened, synchronize]
+  pull_request:
+    types: [opened, synchronize, labeled, unlabeled, reopened]
+
 jobs:
   build-compilation-db:
     name: Build with IWYU
@@ -119,6 +120,9 @@ jobs:
   changelog:
     name: Changelog check
     runs-on: ubuntu-24.04
+    if: >
+      github.event_name != 'pull_request' ||
+      !contains(toJson(github.event.pull_request.labels.*.name), 'skip-changelog')
     steps:
     - uses: dangoslen/changelog-enforcer@v3
       with:

--- a/.github/workflows/static_checks.yaml
+++ b/.github/workflows/static_checks.yaml
@@ -3,7 +3,7 @@ run-name: Static checks
 
 on:
   pull_request:
-    types: [opened, synchronize, labeled, unlabeled, reopened]
+    types: [opened, synchronize, reopened]
 
 jobs:
   build-compilation-db:
@@ -117,13 +117,3 @@ jobs:
         NTODOS="$(grep -r 'TODO DONT MERGE' --exclude-dir=.github | wc -l)"
         echo "Found $NTODOS TODO DONT MERGE notes"
         ! grep -q -r "TODO DONT MERGE" --exclude-dir=.github
-  changelog:
-    name: Changelog check
-    runs-on: ubuntu-24.04
-    if: >
-      github.event_name != 'pull_request' ||
-      !contains(toJson(github.event.pull_request.labels.*.name), 'skip-changelog')
-    steps:
-    - uses: dangoslen/changelog-enforcer@v3
-      with:
-        changeLogPath: CHANGELOG.md


### PR DESCRIPTION
The original static checks only run for an opened PR or new commits. A reopened PR is not considered, but should also be checked.

Originally, the changelog check is included in the static checks. However, the types of PRs for the changelog check can be different from the types of PRs for static checks: the changelog check workflow can also be triggered by **a label change** for an opened PR. Therefore, the changelog check should be defined in a separate workflow.

Whenever the `skip-changelog` label is present, the changelog check will be skipped.