### PR TITLE
Use docker images with Ginkgo pre-installed for GPUs in LRZ GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@
 # Available GPUs and corresponding Docker images
 .use-nvidia-gpu-and-image:
   tags: ["nvidia-h100-gpus"]
-  image: chihtaw/cuda-openfoam-benchmark:v2412
+  image: chihtaw/cuda-openfoam-ginkgo:v2412
   variables:
     PYTHONPATH: /root/.local/:/root/.local/lib/:/root/.local/lib/python3.12:/root/.local/lib/python3.12/site-packages
     FOAM_INST_DIR: /usr/local/app/openfoam

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@
 # Available GPUs and corresponding Docker images
 .use-nvidia-gpu-and-image:
   tags: ["nvidia-h100-gpus"]
-  image: chihtaw/cuda-openfoam-ginkgo:v2412
+  image: chihtaw/cuda-openfoam-ginkgo:arch_90-v2412
   variables:
     PYTHONPATH: /root/.local/:/root/.local/lib/:/root/.local/lib/python3.12:/root/.local/lib/python3.12/site-packages
     FOAM_INST_DIR: /usr/local/app/openfoam
@@ -13,7 +13,7 @@
 
 .use-amd-gpu-and-image:
   tags: ["amd-gpus"]
-  image: chihtaw/rocm-openfoam-ginkgo:6.4.1-v2412
+  image: chihtaw/rocm-openfoam-ginkgo:arch_gfx90a-6.4.1-v2412
   variables:
     PYTHONPATH: /root/.local/:/root/.local/lib/:/root/.local/lib/python3.12:/root/.local/lib/python3.12/site-packages
     FOAM_INST_DIR: /workspace/openfoam

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@
 
 .use-amd-gpu-and-image:
   tags: ["amd-gpus"]
-  image: chihtaw/rocm-openfoam-benchmark:6.4.1-v2412
+  image: chihtaw/rocm-openfoam-ginkgo:6.4.1-v2412
   variables:
     PYTHONPATH: /root/.local/:/root/.local/lib/:/root/.local/lib/python3.12:/root/.local/lib/python3.12/site-packages
     FOAM_INST_DIR: /workspace/openfoam


### PR DESCRIPTION
**Use docker images with Ginkgo pre-installed for particular GPUs in LRZ GitLab CI**:

- NVIDIA H100
- AMD MI210

With the new docker images, all CI jobs on LRZ GitLab use the system-installed Ginkgo instead of building Ginkgo from scratch. Therefore, the time required for build step is significantly reduced. 

**In short**: 
The PR decreases the time developers spend waiting for CI to finish.