### PR TITLE
Updates the latest documentation only when merged to main branch

### DIFF
--- a/.github/workflows/build_doc.yaml
+++ b/.github/workflows/build_doc.yaml
@@ -47,7 +47,7 @@ jobs:
         folder: docs_build
         target-folder: ${{ github.ref_name }}
     - name: Deploy Latest Build
-      if: ${{ github.event.pull_request.merged }}
+      if: ${{ github.event.pull_request.merged && github.event.pull_request.base.ref == 'main' }}
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         folder: docs_build


### PR DESCRIPTION
The current CI job for building and deploying documentation always updates the documentation of the repo whenever a PR is merged to any branch. However, it should happen only when the target branch is the main branch.

This PR modifies the documentation deployment so that the CI job updates the documentation of the repo only when a PR is merged to the main branch.

Closes #123 