### PR TITLE
Automatic merging interdependent branches on NeoFOAM and NeoN 

### DIFF
--- a/.github/workflows/coordinated-merge.yaml
+++ b/.github/workflows/coordinated-merge.yaml
@@ -85,8 +85,7 @@ jobs:
           gh pr merge "$neon_pr_number" \
             --repo $NEON_REPO \
             --merge \
-            --admin \
-            --delete-branch
+            --admin
           echo "NeoN PR merged."
 
       - name: Merge FoamAdapter PR
@@ -96,8 +95,7 @@ jobs:
           gh pr merge ${{ github.event.pull_request.number }} \
             --repo $FOAM_REPO \
             --merge \
-            --admin \
-            --delete-branch
+            --admin
           echo "FoamAdapter PR merged."
 
       # - name: Trigger LRZ GitLab CI

--- a/.github/workflows/coordinated-merge.yaml
+++ b/.github/workflows/coordinated-merge.yaml
@@ -1,0 +1,72 @@
+name: Coordinated Merge for Existing PRs (NeoN + FoamAdapter)
+
+on:
+  workflow_dispatch:
+    inputs:
+      neon_pr:
+        description: "NeoN PR number (e.g. 123)"
+        required: true
+      foam_pr:
+        description: "FoamAdapter PR number (e.g. 456)"
+        required: true
+
+jobs:
+  coordinated-merge:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.MERGE_TOKEN }}
+      NEON_REPO: your-org/NeoN
+      FOAM_REPO: your-org/FoamAdapter
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check NeoN PR approval
+        run: |
+          echo "Checking approval for NeoN PR #${{ github.event.inputs.neon_pr }}..."
+          approved=$(gh pr view ${{ github.event.inputs.neon_pr }} --repo $NEON_REPO --json reviewDecision -q '.reviewDecision')
+          if [[ "$approved" != "APPROVED" ]]; then
+            echo "NeoN PR not yet approved."
+            exit 1
+          fi
+          echo "NeoN PR approved."
+
+      - name: Check FoamAdapter PR approval
+        run: |
+          echo "Checking approval for FoamAdapter PR #${{ github.event.inputs.foam_pr }}..."
+          approved=$(gh pr view ${{ github.event.inputs.foam_pr }} --repo $FOAM_REPO --json reviewDecision -q '.reviewDecision')
+          if [[ "$approved" != "APPROVED" ]]; then
+            echo "FoamAdapter PR not yet approved."
+            exit 1
+          fi
+          echo "FoamAdapter PR approved."
+
+      - name: Merge NeoN PR
+        run: |
+          echo "Merging NeoN PR..."
+          gh pr merge ${{ github.event.inputs.neon_pr }} \
+            --repo $NEON_REPO \
+            --merge \
+            --admin \
+            --delete-branch
+          echo "NeoN PR merged into develop."
+
+      - name: Merge FoamAdapter PR
+        run: |
+          echo "Merging FoamAdapter PR..."
+          gh pr merge ${{ github.event.inputs.foam_pr }} \
+            --repo $FOAM_REPO \
+            --merge \
+            --admin \
+            --delete-branch
+          echo "FoamAdapter PR merged into develop."
+
+      # - name: Trigger LRZ GitLab CI
+      #   run: |
+      #     echo "Triggering LRZ GitLab CI pipelines for both repos..."
+      #     ./scripts/trigger-lrz-ci.sh NeoN develop
+      #     ./scripts/trigger-lrz-ci.sh FoamAdapter develop
+
+      # - name: Done
+      #   run: echo "Both PRs merged and LRZ CI triggered successfully!"

--- a/.github/workflows/coordinated-merge.yaml
+++ b/.github/workflows/coordinated-merge.yaml
@@ -1,51 +1,61 @@
-name: Coordinated Merge for Existing PRs (NeoN + FoamAdapter)
+name: Coordinated Merge for FoamAdapter + NeoN
 
 on:
-  workflow_dispatch:
-    inputs:
-      neon_pr:
-        description: "NeoN PR number (e.g. 123)"
-        required: true
-      foam_pr:
-        description: "FoamAdapter PR number (e.g. 456)"
-        required: true
+  pull_request:
+    types: [labeled, unlabeled, synchronize, reopened, opened]
+    branches:
+      - develop
 
 jobs:
   coordinated-merge:
+    if: contains(github.event.pull_request.labels.*.name, 'coordinated-merge')
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.MERGE_TOKEN }}
       NEON_REPO: exasim-project/NeoN
       FOAM_REPO: exasim-project/FoamAdapter
+      BRANCH_NAME: ${{ github.head_ref }}
 
     steps:
-      - name: Checkout
+      - name: Checkout FoamAdapter repository
         uses: actions/checkout@v4
 
-      - name: Check NeoN PR approval
+      - name: Confirm triggering context
         run: |
-          echo "Checking approval for NeoN PR #${{ github.event.inputs.neon_pr }}..."
-          approved=$(gh pr view ${{ github.event.inputs.neon_pr }} --repo $NEON_REPO --json reviewDecision -q '.reviewDecision')
-          if [[ "$approved" != "APPROVED" ]]; then
-            echo "NeoN PR not yet approved."
-            exit 1
-          fi
-          echo "NeoN PR approved."
+          echo "Triggered from FoamAdapter PR: #${{ github.event.pull_request.number }}"
+          echo "Branch name: $BRANCH_NAME"
+          echo "Label: coordinated-merge detected"
 
       - name: Check FoamAdapter PR approval
         run: |
-          echo "Checking approval for FoamAdapter PR #${{ github.event.inputs.foam_pr }}..."
-          approved=$(gh pr view ${{ github.event.inputs.foam_pr }} --repo $FOAM_REPO --json reviewDecision -q '.reviewDecision')
+          echo "Checking approval for FoamAdapter PR..."
+          approved=$(gh pr view ${{ github.event.pull_request.number }} --repo $FOAM_REPO --json reviewDecision -q '.reviewDecision')
           if [[ "$approved" != "APPROVED" ]]; then
             echo "FoamAdapter PR not yet approved."
             exit 1
           fi
           echo "FoamAdapter PR approved."
 
+      - name: Check NeoN PR approval
+        run: |
+          echo "Checking approval for NeoN PR with branch '$BRANCH_NAME'..."
+          neon_pr=$(gh pr list --repo $NEON_REPO --head $BRANCH_NAME --json number -q '.[0].number')
+          if [[ -z "$neon_pr" ]]; then
+            echo "No matching NeoN PR found for branch '$BRANCH_NAME'."
+            exit 1
+          fi
+          echo "Found NeoN PR #$neon_pr"
+          approved=$(gh pr view $neon_pr --repo $NEON_REPO --json reviewDecision -q '.reviewDecision')
+          if [[ "$approved" != "APPROVED" ]]; then
+            echo "NeoN PR not yet approved."
+            exit 1
+          fi
+          echo "NeoN PR approved."
+
       - name: Merge NeoN PR
         run: |
           echo "Merging NeoN PR..."
-          gh pr merge ${{ github.event.inputs.neon_pr }} \
+          gh pr merge "$neon_pr" \
             --repo $NEON_REPO \
             --merge \
             --admin \
@@ -55,7 +65,7 @@ jobs:
       - name: Merge FoamAdapter PR
         run: |
           echo "Merging FoamAdapter PR..."
-          gh pr merge ${{ github.event.inputs.foam_pr }} \
+          gh pr merge ${{ github.event.pull_request.number }} \
             --repo $FOAM_REPO \
             --merge \
             --admin \
@@ -68,5 +78,5 @@ jobs:
       #     ./scripts/trigger-lrz-ci.sh NeoN develop
       #     ./scripts/trigger-lrz-ci.sh FoamAdapter develop
 
-      # - name: Done
-      #   run: echo "Both PRs merged and LRZ CI triggered successfully!"
+      - name: Done
+        run: echo "Both PRs merged successfully."

--- a/.github/workflows/coordinated-merge.yaml
+++ b/.github/workflows/coordinated-merge.yaml
@@ -98,11 +98,5 @@ jobs:
             --admin
           echo "FoamAdapter PR merged."
 
-      # - name: Trigger LRZ GitLab CI
-      #   run: |
-      #     echo "Triggering LRZ GitLab CI pipelines for both repos..."
-      #     ./scripts/trigger-lrz-ci.sh NeoN "$neon_base"
-      #     ./scripts/trigger-lrz-ci.sh FoamAdapter "$foam_base"
-
       - name: Done
         run: echo "Coordinated merge completed successfully."

--- a/.github/workflows/coordinated-merge.yaml
+++ b/.github/workflows/coordinated-merge.yaml
@@ -3,8 +3,6 @@ name: Coordinated Merge for FoamAdapter + NeoN
 on:
   pull_request:
     types: [labeled, unlabeled, synchronize, reopened, opened]
-    branches:
-      - develop
 
 jobs:
   coordinated-merge:
@@ -25,6 +23,7 @@ jobs:
           echo "Triggered from FoamAdapter PR: #${{ github.event.pull_request.number }}"
           echo "Branch name: $BRANCH_NAME"
           echo "Label: coordinated-merge detected"
+          echo "FoamAdapter PR base branch: ${{ github.event.pull_request.base.ref }}"
 
       - name: Check FoamAdapter PR approval
         run: |
@@ -36,16 +35,42 @@ jobs:
           fi
           echo "FoamAdapter PR approved."
 
-      - name: Check NeoN PR approval
+      - name: Find NeoN PR with same branch
+        id: find-neon
         run: |
-          echo "Checking approval for NeoN PR with branch '$BRANCH_NAME'..."
-          neon_pr=$(gh pr list --repo $NEON_REPO --head $BRANCH_NAME --json number -q '.[0].number')
+          echo "Looking for NeoN PR with branch '$BRANCH_NAME'..."
+          neon_pr=$(gh pr list --repo $NEON_REPO --head $BRANCH_NAME --json number,baseRefName -q '.[0]')
           if [[ -z "$neon_pr" ]]; then
             echo "No matching NeoN PR found for branch '$BRANCH_NAME'."
             exit 1
           fi
-          echo "Found NeoN PR #$neon_pr"
-          approved=$(gh pr view $neon_pr --repo $NEON_REPO --json reviewDecision -q '.reviewDecision')
+
+          neon_pr_number=$(echo $neon_pr | jq -r '.number')
+          neon_pr_base=$(echo $neon_pr | jq -r '.baseRefName')
+          echo "Found NeoN PR #$neon_pr_number targeting branch '$neon_pr_base'"
+
+          echo "neon_pr_number=$neon_pr_number" >> $GITHUB_OUTPUT
+          echo "neon_pr_base=$neon_pr_base" >> $GITHUB_OUTPUT
+
+      - name: Verify base branches match
+        run: |
+          foam_base="${{ github.event.pull_request.base.ref }}"
+          neon_base="${{ steps.find-neon.outputs.neon_pr_base }}"
+
+          echo "FoamAdapter PR base: $foam_base"
+          echo "NeoN PR base: $neon_base"
+
+          if [[ "$foam_base" != "$neon_base" ]]; then
+            echo "Base branches do not match. Cannot perform coordinated merge."
+            exit 1
+          fi
+          echo "Base branches match."
+
+      - name: Check NeoN PR approval
+        run: |
+          neon_pr_number="${{ steps.find-neon.outputs.neon_pr_number }}"
+          echo "Checking approval for NeoN PR #$neon_pr_number..."
+          approved=$(gh pr view "$neon_pr_number" --repo $NEON_REPO --json reviewDecision -q '.reviewDecision')
           if [[ "$approved" != "APPROVED" ]]; then
             echo "NeoN PR not yet approved."
             exit 1
@@ -54,29 +79,32 @@ jobs:
 
       - name: Merge NeoN PR
         run: |
-          echo "Merging NeoN PR..."
-          gh pr merge "$neon_pr" \
+          neon_pr_number="${{ steps.find-neon.outputs.neon_pr_number }}"
+          neon_base="${{ steps.find-neon.outputs.neon_pr_base }}"
+          echo "Merging NeoN PR #$neon_pr_number into $neon_base..."
+          gh pr merge "$neon_pr_number" \
             --repo $NEON_REPO \
             --merge \
             --admin \
             --delete-branch
-          echo "NeoN PR merged into develop."
+          echo "NeoN PR merged."
 
       - name: Merge FoamAdapter PR
         run: |
-          echo "Merging FoamAdapter PR..."
+          foam_base="${{ github.event.pull_request.base.ref }}"
+          echo "Merging FoamAdapter PR #${{ github.event.pull_request.number }} into $foam_base..."
           gh pr merge ${{ github.event.pull_request.number }} \
             --repo $FOAM_REPO \
             --merge \
             --admin \
             --delete-branch
-          echo "FoamAdapter PR merged into develop."
+          echo "FoamAdapter PR merged."
 
       # - name: Trigger LRZ GitLab CI
       #   run: |
       #     echo "Triggering LRZ GitLab CI pipelines for both repos..."
-      #     ./scripts/trigger-lrz-ci.sh NeoN develop
-      #     ./scripts/trigger-lrz-ci.sh FoamAdapter develop
+      #     ./scripts/trigger-lrz-ci.sh NeoN "$neon_base"
+      #     ./scripts/trigger-lrz-ci.sh FoamAdapter "$foam_base"
 
       - name: Done
-        run: echo "Both PRs merged successfully."
+        run: echo "Coordinated merge completed successfully."

--- a/.github/workflows/coordinated-merge.yaml
+++ b/.github/workflows/coordinated-merge.yaml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.MERGE_TOKEN }}
-      NEON_REPO: your-org/NeoN
-      FOAM_REPO: your-org/FoamAdapter
+      NEON_REPO: exasim-project/NeoN
+      FOAM_REPO: exasim-project/FoamAdapter
 
     steps:
       - name: Checkout

--- a/.github/workflows/coordinated-merge.yaml
+++ b/.github/workflows/coordinated-merge.yaml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout FoamAdapter repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
 
       - name: Confirm triggering context
         run: |
@@ -27,18 +29,15 @@ jobs:
 
       - name: Check FoamAdapter PR approval
         run: |
-          echo "Checking approval for FoamAdapter PR..."
           approved=$(gh pr view ${{ github.event.pull_request.number }} --repo $FOAM_REPO --json reviewDecision -q '.reviewDecision')
           if [[ "$approved" != "APPROVED" ]]; then
             echo "FoamAdapter PR not yet approved."
             exit 1
           fi
-          echo "FoamAdapter PR approved."
 
       - name: Find NeoN PR with same branch
         id: find-neon
         run: |
-          echo "Looking for NeoN PR with branch '$BRANCH_NAME'..."
           neon_pr=$(gh pr list --repo $NEON_REPO --head $BRANCH_NAME --json number,baseRefName -q '.[0]')
           if [[ -z "$neon_pr" ]]; then
             echo "No matching NeoN PR found for branch '$BRANCH_NAME'."
@@ -47,7 +46,6 @@ jobs:
 
           neon_pr_number=$(echo $neon_pr | jq -r '.number')
           neon_pr_base=$(echo $neon_pr | jq -r '.baseRefName')
-          echo "Found NeoN PR #$neon_pr_number targeting branch '$neon_pr_base'"
 
           echo "neon_pr_number=$neon_pr_number" >> $GITHUB_OUTPUT
           echo "neon_pr_base=$neon_pr_base" >> $GITHUB_OUTPUT
@@ -57,46 +55,55 @@ jobs:
           foam_base="${{ github.event.pull_request.base.ref }}"
           neon_base="${{ steps.find-neon.outputs.neon_pr_base }}"
 
-          echo "FoamAdapter PR base: $foam_base"
-          echo "NeoN PR base: $neon_base"
-
           if [[ "$foam_base" != "$neon_base" ]]; then
             echo "Base branches do not match. Cannot perform coordinated merge."
             exit 1
           fi
-          echo "Base branches match."
 
       - name: Check NeoN PR approval
         run: |
           neon_pr_number="${{ steps.find-neon.outputs.neon_pr_number }}"
-          echo "Checking approval for NeoN PR #$neon_pr_number..."
           approved=$(gh pr view "$neon_pr_number" --repo $NEON_REPO --json reviewDecision -q '.reviewDecision')
           if [[ "$approved" != "APPROVED" ]]; then
             echo "NeoN PR not yet approved."
             exit 1
           fi
-          echo "NeoN PR approved."
+
+      - name: Dry-run both merges locally
+        run: |
+          set -e
+          # Clone both repos into temp dirs
+          TMP_DIR=$(mktemp -d)
+          git clone https://github.com/$FOAM_REPO.git $TMP_DIR/foam
+          git clone https://github.com/$NEON_REPO.git $TMP_DIR/neon
+
+          # Checkout base branches
+          cd $TMP_DIR/foam
+          git checkout ${{ github.event.pull_request.base.ref }}
+          git fetch origin $BRANCH_NAME
+          git merge --no-commit --no-ff origin/$BRANCH_NAME || { echo "FoamAdapter merge would fail"; exit 1; }
+
+          cd $TMP_DIR/neon
+          git checkout ${{ steps.find-neon.outputs.neon_pr_base }}
+          git fetch origin $BRANCH_NAME
+          git merge --no-commit --no-ff origin/$BRANCH_NAME || { echo "NeoN merge would fail"; exit 1; }
+
+          echo "Dry-run merge succeeded for both PRs."
 
       - name: Merge NeoN PR
         run: |
           neon_pr_number="${{ steps.find-neon.outputs.neon_pr_number }}"
-          neon_base="${{ steps.find-neon.outputs.neon_pr_base }}"
-          echo "Merging NeoN PR #$neon_pr_number into $neon_base..."
           gh pr merge "$neon_pr_number" \
             --repo $NEON_REPO \
             --merge \
             --admin
-          echo "NeoN PR merged."
 
       - name: Merge FoamAdapter PR
         run: |
-          foam_base="${{ github.event.pull_request.base.ref }}"
-          echo "Merging FoamAdapter PR #${{ github.event.pull_request.number }} into $foam_base..."
           gh pr merge ${{ github.event.pull_request.number }} \
             --repo $FOAM_REPO \
             --merge \
             --admin
-          echo "FoamAdapter PR merged."
 
       - name: Done
         run: echo "Coordinated merge completed successfully."

--- a/.github/workflows/coordinated-merge.yaml
+++ b/.github/workflows/coordinated-merge.yaml
@@ -77,12 +77,17 @@ jobs:
           git clone https://github.com/$FOAM_REPO.git $TMP_DIR/foam
           git clone https://github.com/$NEON_REPO.git $TMP_DIR/neon
 
-          # Checkout base branches
+          # Configure git identity for merge commits
+          git config --global user.email "ci-bot@example.com"
+          git config --global user.name "CI Bot"
+
+          # Checkout base branches and dry-run merge FoamAdapter
           cd $TMP_DIR/foam
           git checkout ${{ github.event.pull_request.base.ref }}
           git fetch origin $BRANCH_NAME
           git merge --no-commit --no-ff origin/$BRANCH_NAME || { echo "FoamAdapter merge would fail"; exit 1; }
 
+          # Dry-run merge NeoN
           cd $TMP_DIR/neon
           git checkout ${{ steps.find-neon.outputs.neon_pr_base }}
           git fetch origin $BRANCH_NAME

--- a/.github/workflows/coordinated-merge.yaml
+++ b/.github/workflows/coordinated-merge.yaml
@@ -1,4 +1,4 @@
-name: Coordinated Merge for FoamAdapter + NeoN
+name: Coordinated Merge for NeoFOAM + NeoN
 
 on:
   pull_request:
@@ -11,27 +11,27 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.MERGE_TOKEN }}
       NEON_REPO: exasim-project/NeoN
-      FOAM_REPO: exasim-project/FoamAdapter
+      FOAM_REPO: exasim-project/NeoFOAM
       BRANCH_NAME: ${{ github.head_ref }}
 
     steps:
-      - name: Checkout FoamAdapter repository
+      - name: Checkout NeoFOAM repository
         uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
 
       - name: Confirm triggering context
         run: |
-          echo "Triggered from FoamAdapter PR: #${{ github.event.pull_request.number }}"
+          echo "Triggered from NeoFOAM PR: #${{ github.event.pull_request.number }}"
           echo "Branch name: $BRANCH_NAME"
           echo "Label: coordinated-merge detected"
-          echo "FoamAdapter PR base branch: ${{ github.event.pull_request.base.ref }}"
+          echo "NeoFOAM PR base branch: ${{ github.event.pull_request.base.ref }}"
 
-      - name: Check FoamAdapter PR approval
+      - name: Check NeoFOAM PR approval
         run: |
           approved=$(gh pr view ${{ github.event.pull_request.number }} --repo $FOAM_REPO --json reviewDecision -q '.reviewDecision')
           if [[ "$approved" != "APPROVED" ]]; then
-            echo "FoamAdapter PR not yet approved."
+            echo "NeoFOAM PR not yet approved."
             exit 1
           fi
 
@@ -81,11 +81,11 @@ jobs:
           git config --global user.email "ci-bot@example.com"
           git config --global user.name "CI Bot"
 
-          # Checkout base branches and dry-run merge FoamAdapter
+          # Checkout base branches and dry-run merge NeoFOAM
           cd $TMP_DIR/foam
           git checkout ${{ github.event.pull_request.base.ref }}
           git fetch origin $BRANCH_NAME
-          git merge --no-commit --no-ff origin/$BRANCH_NAME || { echo "FoamAdapter merge would fail"; exit 1; }
+          git merge --no-commit --no-ff origin/$BRANCH_NAME || { echo "NeoFOAM merge would fail"; exit 1; }
 
           # Dry-run merge NeoN
           cd $TMP_DIR/neon
@@ -103,7 +103,7 @@ jobs:
             --merge \
             --admin
 
-      - name: Merge FoamAdapter PR
+      - name: Merge NeoFOAM PR
         run: |
           gh pr merge ${{ github.event.pull_request.number }} \
             --repo $FOAM_REPO \


### PR DESCRIPTION
### Motivation

When a branch with breaking changes is introduced on NeoN, another branch from NeoFOAM is required to adapt to the changes in NeoN. If the NeoN's branch is merged manually before the NeoFOAM's branch is merged, the NeoFOAM will be broken.

There is a need of a mechanism to coordinate the merging of two branches so that the two branches with merged changes on both NeoFOAM and NeoN can still work together.

### Idea

- Both branches on NeoFOAM and NeoN which should work together need to be finished before merging.
- Both branches need to be merged at the same time (or in a very short time).

### Approach: Coordinated merge

**The procedure**:

1. Two feature branches on NeoFOAM and NeoN which should work together have to use the same branch name.
2. The two PRs for the two branches need to have target branches with the same branch name.
3. Both the two PRs need to be approved before merging.
4. Merging of the two PRs on both NeoFOAM and NeoN is performed automatically via a pre-defined GitHub workflow by adding the PR label `coordinated-merge`.

**Note**:
The automatic merging of the two PRs should be done in NeoFOAM because NeoFOAM is the downstream repo of NeoN. Merging should take place only when NeoFOAM's PR is done and ready to merge. 