### PR TITLE
Fix the name of the fluid flow solver in tutorials

### DIFF
--- a/tutorials/cavity/Allrun
+++ b/tutorials/cavity/Allrun
@@ -7,7 +7,7 @@ restore0Dir
 
 runApplication blockMesh
 
-runApplication ../../build/profiling/bin/icoNeoFoam
+runApplication ../../build/profiling/bin/neoIcoFoam
 # runApplication icoFoam
 
 #------------------------------------------------------------------------------

--- a/tutorials/cylinder2D/Allrun
+++ b/tutorials/cylinder2D/Allrun
@@ -7,7 +7,7 @@ restore0Dir
 
 runApplication blockMesh
 
-# runApplication ../../build/profiling/bin/icoNeoFoam
-runApplication icoFoam
+runApplication ../../build/profiling/bin/neoIcoFoam
+# runApplication icoFoam
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
A wrong name is used for the fluid flow solver: `icoNeoFoam`

Since there is no solver with this name, the tutorial cases using the wrong name will immediately fail.

Fix: Use `neoIcoFoam` to run the tutorial cases.