### PR TITLE
Fix issue with int to scalar conversion

### DIFF
--- a/examples/neoIcoFoam/neoIcoFoam.cpp
+++ b/examples/neoIcoFoam/neoIcoFoam.cpp
@@ -35,7 +35,7 @@ int main(int argc, char* argv[])
 #include "createFields.H"
 
         // TODO have central place for the mapper
-        auto& solverDict = rt.fvSolutionDict.get<NeoN::Dictionary>("solvers");
+        auto& solverDict = rt.fvSolutionDict.subDict("solvers");
         solverDict.get<NeoN::Dictionary>("p") =
             nf::mapFvSolution(solverDict.get<NeoN::Dictionary>("p"));
         solverDict.get<NeoN::Dictionary>("U") =

--- a/examples/neoIcoFoam/neoIcoFoam.cpp
+++ b/examples/neoIcoFoam/neoIcoFoam.cpp
@@ -36,10 +36,8 @@ int main(int argc, char* argv[])
 
         // TODO have central place for the mapper
         auto& solverDict = rt.fvSolutionDict.subDict("solvers");
-        solverDict.get<NeoN::Dictionary>("p") =
-            nf::mapFvSolution(solverDict.get<NeoN::Dictionary>("p"));
-        solverDict.get<NeoN::Dictionary>("U") =
-            nf::mapFvSolution(solverDict.get<NeoN::Dictionary>("U"));
+        solverDict.subDict("p") = nf::mapFvSolution(solverDict.subDict("p"));
+        solverDict.subDict("U") = nf::mapFvSolution(solverDict.subDict("U"));
 
         Info << "creating nf pressure field" << endl;
         fvcc::VectorCollection& vectorCollection =

--- a/include/NeoFOAM/auxiliary/readers.hpp
+++ b/include/NeoFOAM/auxiliary/readers.hpp
@@ -45,7 +45,7 @@ auto readVolBoundaryConditions(const NeoN::UnstructuredMesh& nfMesh, const FoamT
          [](auto& dict)
          {
              dict.insert("type", std::string("fixedGradient"));
-             NeoN::TokenList tokenList = dict.template get<NeoN::TokenList>("value");
+             NeoN::TokenList tokenList = dict.template getVal<NeoN::TokenList>("value");
              type_primitive_t fixedGradient = tokenList.get<type_primitive_t>(1);
              dict.insert("fixedGradient", fixedGradient);
          }},
@@ -59,7 +59,7 @@ auto readVolBoundaryConditions(const NeoN::UnstructuredMesh& nfMesh, const FoamT
          [](auto& dict)
          {
              dict.insert("type", std::string("fixedValue"));
-             NeoN::TokenList tokenList = dict.template get<NeoN::TokenList>("value");
+             NeoN::TokenList tokenList = dict.template getVal<NeoN::TokenList>("value");
              type_primitive_t fixedValue {};
              if (std::is_same<type_primitive_t, NeoN::Vec3>::value)
              {

--- a/include/NeoFOAM/datastructures/pdeSolver.hpp
+++ b/include/NeoFOAM/datastructures/pdeSolver.hpp
@@ -149,8 +149,8 @@ private:
                     : std::vector<NeoN::dsl::PostAssemblyBase<ValueType>> {};
         }
 
-        auto solverDict = runTime_.fvSolutionDict.get<NeoN::Dictionary>("solvers");
-        auto fieldSolverDict = solverDict.get<NeoN::Dictionary>(psi_.name);
+        auto solverDict = runTime_.fvSolutionDict.subDict("solvers");
+        auto fieldSolverDict = solverDict.subDict(psi_.name);
 
         auto stats = NeoN::dsl::detail::iterativeSolveImpl(
             expr,

--- a/src/algorithms/pressureVelocityCoupling.cpp
+++ b/src/algorithms/pressureVelocityCoupling.cpp
@@ -178,7 +178,7 @@ void updateFaceVelocity(
     );
 
     auto& bcCoeffs =
-        ls.auxiliaryCoefficients().get<la::BoundaryCoefficients<NeoN::scalar, NeoN::localIdx>>(
+        ls.auxiliaryCoefficients().getRef<la::BoundaryCoefficients<NeoN::scalar, NeoN::localIdx>>(
             "boundaryCoefficients"
         );
 

--- a/src/algorithms/pressureVelocityCoupling.cpp
+++ b/src/algorithms/pressureVelocityCoupling.cpp
@@ -177,7 +177,7 @@ void updateFaceVelocity(
         mesh.boundaryMesh().faceCells()
     );
 
-    auto& bcCoeffs =
+    const auto& bcCoeffs =
         ls.auxiliaryCoefficients().getRef<la::BoundaryCoefficients<NeoN::scalar, NeoN::localIdx>>(
             "boundaryCoefficients"
         );

--- a/src/compatibility/fvSolution.cpp
+++ b/src/compatibility/fvSolution.cpp
@@ -27,7 +27,7 @@ void updateSolver(NeoN::Dictionary& solverDict)
         {"GAMG", {"Ginkgo", "solver::Multigrid"}},
     };
 
-    std::string& solverName = solverDict.get<std::string>("solver");
+    std::string& solverName = solverDict.getRef<std::string>("solver");
     auto it = solverMap.find(solverName);
     if (it != solverMap.end())
     {
@@ -92,7 +92,7 @@ void updatePreconditioner(NeoN::Dictionary& solverDict)
     else
     {
         // If no preconditioner is specified, we can insert a default one
-        std::string& preconditionerName = solverDict.get<std::string>("preconditioner");
+        std::string& preconditionerName = solverDict.getRef<std::string>("preconditioner");
         auto it = preconditionerMap.find(preconditionerName);
         if (it != preconditionerMap.end())
         {

--- a/src/compatibility/fvSolution.cpp
+++ b/src/compatibility/fvSolution.cpp
@@ -121,19 +121,19 @@ void updateCriteria(NeoN::Dictionary& solverDict)
     if (solverDict.contains("relTol"))
     {
         NeoN::Dictionary& criteriaDict = solverDict.subDict("criteria");
-        criteriaDict.insert("relative_residual_norm", solverDict.get<NeoN::scalar>("relTol"));
+        criteriaDict.insert("relative_residual_norm", solverDict.getVal<NeoN::scalar>("relTol"));
         solverDict.remove("relTol");
     }
     if (solverDict.contains("maxIter"))
     {
         NeoN::Dictionary& criteriaDict = solverDict.subDict("criteria");
-        criteriaDict.insert("iteration", solverDict.get<NeoN::label>("maxIter"));
+        criteriaDict.insert("iteration", solverDict.getVal<NeoN::label>("maxIter"));
         solverDict.remove("maxIter");
     }
     if (solverDict.contains("tolerance"))
     {
         NeoN::Dictionary& criteriaDict = solverDict.subDict("criteria");
-        criteriaDict.insert("absolute_residual_norm", solverDict.get<NeoN::scalar>("tolerance"));
+        criteriaDict.insert("absolute_residual_norm", solverDict.getVal<NeoN::scalar>("tolerance"));
         solverDict.remove("tolerance");
     }
 

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -14,8 +14,8 @@
 #include "catch2/common.hpp"
 
 #include "NeoN/NeoN.hpp"
-#include "catch2/executorGenerator.hpp"
 #include "NeoFOAM/NeoFOAM.hpp"
+#include "catch2/executorGenerator.hpp"
 
 #include "fvm.H"
 #include "fvc.H"

--- a/test/test_advection.cpp
+++ b/test/test_advection.cpp
@@ -118,7 +118,7 @@ TEST_CASE("Advection Equation")
     SECTION("Scalar advection with " + execName + " and " + "forwardEuler")
     {
         std::string timeIntegration = "forwardEuler";
-        fvSchemesDict.get<NeoN::Dictionary>("ddtSchemes").insert("type", timeIntegration);
+        fvSchemesDict.subDict("ddtSchemes").insert("type", timeIntegration);
 
         while (runTime.run())
         {
@@ -182,7 +182,7 @@ TEST_CASE("Advection Equation")
 
     SECTION("Scalar advection with " + execName + " and " + timeIntegration)
     {
-        fvSchemesDict.get<NeoN::Dictionary>("ddtSchemes").insert("type", timeIntegration);
+        fvSchemesDict.subDict("ddtSchemes").insert("type", timeIntegration);
 
         while (runTime.run())
         {

--- a/test/test_advection.cpp
+++ b/test/test_advection.cpp
@@ -49,6 +49,9 @@ void initFields(Foam::volScalarField& T, Foam::volVectorField& U, Foam::surfaceS
 TEST_CASE("Advection Equation")
 {
     Foam::Time& runTime = *timePtr;
+    Info << "Foo bbar bbaz\n";
+    // Info.level = 0;
+    // Info<< "Foo bbar bbaz 222 \n";
 
     NeoN::Database db;
     fvcc::VectorCollection& vectorCollection =

--- a/test/test_advection.cpp
+++ b/test/test_advection.cpp
@@ -49,9 +49,6 @@ void initFields(Foam::volScalarField& T, Foam::volVectorField& U, Foam::surfaceS
 TEST_CASE("Advection Equation")
 {
     Foam::Time& runTime = *timePtr;
-    Info << "Foo bbar bbaz\n";
-    // Info.level = 0;
-    // Info<< "Foo bbar bbaz 222 \n";
 
     NeoN::Database db;
     fvcc::VectorCollection& vectorCollection =
@@ -113,7 +110,6 @@ TEST_CASE("Advection Equation")
     NeoN::Dictionary controlDict = NeoFOAM::convert(runTime.controlDict());
     NeoN::Dictionary fvSchemesDict = NeoFOAM::convert(mesh.schemesDict());
     Foam::scalar endTime = controlDict.get<Foam::scalar>("endTime");
-
 
     SECTION("Scalar advection with " + execName + " and " + "forwardEuler")
     {

--- a/test/test_advection.cpp
+++ b/test/test_advection.cpp
@@ -109,7 +109,7 @@ TEST_CASE("Advection Equation")
 
     NeoN::Dictionary controlDict = NeoFOAM::convert(runTime.controlDict());
     NeoN::Dictionary fvSchemesDict = NeoFOAM::convert(mesh.schemesDict());
-    Foam::scalar endTime = controlDict.get<Foam::scalar>("endTime");
+    Foam::scalar endTime = controlDict.getVal<Foam::scalar>("endTime");
 
     SECTION("Scalar advection with " + execName + " and " + "forwardEuler")
     {

--- a/test/test_compatibility.cpp
+++ b/test/test_compatibility.cpp
@@ -41,22 +41,22 @@ TEST_CASE("fvSolution")
         {
             solver1.insert("solver", std::string("PCG"));
             NeoFOAM::updateSolver(solver1);
-            REQUIRE(solver1.get<std::string>("solver") == "Ginkgo");
-            REQUIRE(solver1.get<std::string>("type") == "solver::Cg");
+            REQUIRE(solver1.getVal<std::string>("solver") == "Ginkgo");
+            REQUIRE(solver1.getVal<std::string>("type") == "solver::Cg");
         }
         SECTION("PBiCG")
         {
             solver1.insert("solver", std::string("PBiCG"));
             NeoFOAM::updateSolver(solver1);
-            REQUIRE(solver1.get<std::string>("solver") == "Ginkgo");
-            REQUIRE(solver1.get<std::string>("type") == "solver::Bicg");
+            REQUIRE(solver1.getVal<std::string>("solver") == "Ginkgo");
+            REQUIRE(solver1.getVal<std::string>("type") == "solver::Bicg");
         }
         SECTION("PBiCGStab")
         {
             solver1.insert("solver", std::string("PBiCGStab"));
             NeoFOAM::updateSolver(solver1);
-            REQUIRE(solver1.get<std::string>("solver") == "Ginkgo");
-            REQUIRE(solver1.get<std::string>("type") == "solver::Bicgstab");
+            REQUIRE(solver1.getVal<std::string>("solver") == "Ginkgo");
+            REQUIRE(solver1.getVal<std::string>("type") == "solver::Bicgstab");
         }
     }
 
@@ -67,18 +67,18 @@ TEST_CASE("fvSolution")
             solver1.insert("preconditioner", std::string("DIC"));
             NeoFOAM::updatePreconditioner(solver1);
             auto& preconditionerDict = solver1.subDict("preconditioner");
-            REQUIRE(preconditionerDict.get<std::string>("type") == "preconditioner::Jacobi");
-            REQUIRE(preconditionerDict.get<int>("max_block_size") == 1);
+            REQUIRE(preconditionerDict.getVal<std::string>("type") == "preconditioner::Jacobi");
+            REQUIRE(preconditionerDict.getVal<int>("max_block_size") == 1);
         }
         SECTION("DILU")
         {
             solver1.insert("preconditioner", std::string("DILU"));
             NeoFOAM::updatePreconditioner(solver1);
             auto& preconditionerDict = solver1.subDict("preconditioner");
-            REQUIRE(preconditionerDict.get<std::string>("type") == "preconditioner::Ilu");
-            REQUIRE(preconditionerDict.get<bool>("reverse_apply") == false);
+            REQUIRE(preconditionerDict.getVal<std::string>("type") == "preconditioner::Ilu");
+            REQUIRE(preconditionerDict.getVal<bool>("reverse_apply") == false);
             REQUIRE(
-                preconditionerDict.subDict("factorization").get<std::string>("type")
+                preconditionerDict.subDict("factorization").getVal<std::string>("type")
                 == "factorization::ParIlu"
             );
         }

--- a/test/test_pressureVelocityCoupling.cpp
+++ b/test/test_pressureVelocityCoupling.cpp
@@ -212,9 +212,8 @@ TEST_CASE("PressureVelocityCoupling")
 
         SECTION("Solve transient momentum without grad(p)")
         {
-            auto& solverDict = rt.fvSolutionDict.get<NeoN::Dictionary>("solvers");
-            solverDict.get<NeoN::Dictionary>("nfU") =
-                nf::mapFvSolution(solverDict.get<NeoN::Dictionary>("nfU"));
+            auto& solverDict = rt.fvSolutionDict.subDict("solvers");
+            solverDict.subDict("nfU") = nf::mapFvSolution(solverDict.subDict("nfU"));
 
             // require fields to be initially the same
             auto hostnfU = nfU.internalVector().copyToHost();
@@ -294,9 +293,8 @@ TEST_CASE("PressureVelocityCoupling")
 
         SECTION("Solve transient momentum with grad(p)")
         {
-            auto& solverDict = rt.fvSolutionDict.get<NeoN::Dictionary>("solvers");
-            solverDict.get<NeoN::Dictionary>("nfU") =
-                nf::mapFvSolution(solverDict.get<NeoN::Dictionary>("nfU"));
+            auto& solverDict = rt.fvSolutionDict.subDict("solvers");
+            solverDict.subDict("nfU") = nf::mapFvSolution(solverDict.subDict("nfU"));
 
             // require fields to be initially the same
             auto hostnfU = nfU.internalVector().copyToHost();

--- a/test/test_readDict.cpp
+++ b/test/test_readDict.cpp
@@ -60,8 +60,8 @@ TEST_CASE("read fvSchemes")
 
     NeoN::TokenList gradU = fvSchemesDict.subDict("gradSchemes").getVal<NeoN::TokenList>("grad(U)");
     REQUIRE(gradU.size() == 2);
-    REQUIRE(gradU.getVal<std::string>(0) == "Gauss");
-    REQUIRE(gradU.getVal<std::string>(1) == "linear");
+    REQUIRE(gradU.get<std::string>(0) == "Gauss");
+    REQUIRE(gradU.get<std::string>(1) == "linear");
 }
 
 TEST_CASE("read testDictionary from disk")

--- a/test/test_readDict.cpp
+++ b/test/test_readDict.cpp
@@ -25,15 +25,15 @@ TEST_CASE("Convert OpenFOAM::dictionary dict to NeoN::Dict")
 
     auto nfDict = NeoFOAM::convert(testDict);
 
-    REQUIRE(nfDict.get<NeoN::label>("label") == 1);
-    REQUIRE(nfDict.get<NeoN::scalar>("scalar") == 2.1);
-    REQUIRE(nfDict.get<NeoN::scalar>("scalar2") == 2.0);
-    REQUIRE(nfDict.get<NeoN::Vec3>("vector") == NeoN::Vec3(1.0, 2.0, 3.0));
-    REQUIRE(nfDict.get<std::string>("word") == "word");
+    REQUIRE(nfDict.getVal<NeoN::label>("label") == 1);
+    REQUIRE(nfDict.getVal<NeoN::scalar>("scalar") == 2.1);
+    REQUIRE(nfDict.getVal<NeoN::scalar>("scalar2") == 2.0);
+    REQUIRE(nfDict.getVal<NeoN::Vec3>("vector") == NeoN::Vec3(1.0, 2.0, 3.0));
+    REQUIRE(nfDict.getVal<std::string>("word") == "word");
 
     auto& nfSubDict = nfDict.subDict("subDict");
-    REQUIRE(nfSubDict.get<NeoN::scalar>("subScalar") == 4.1);
-    REQUIRE(nfSubDict.get<NeoN::Vec3>("subVector") == NeoN::Vec3(5.0, 6.0, 7.0));
+    REQUIRE(nfSubDict.getVal<NeoN::scalar>("subScalar") == 4.1);
+    REQUIRE(nfSubDict.getVal<NeoN::Vec3>("subVector") == NeoN::Vec3(5.0, 6.0, 7.0));
 }
 
 
@@ -48,20 +48,20 @@ TEST_CASE("read fvSchemes")
     NeoN::Dictionary fvSchemesDict = NeoFOAM::convert(mesh.schemesDict());
     auto keys = fvSchemesDict.keys();
 
-    REQUIRE(fvSchemesDict.subDict("ddtSchemes").get<std::string>("ddt(T)") == "Euler");
+    REQUIRE(fvSchemesDict.subDict("ddtSchemes").getVal<std::string>("ddt(T)") == "Euler");
     auto gradSchemeKeys = fvSchemesDict.subDict("gradSchemes").keys();
     NeoN::TokenList limitedToken =
-        fvSchemesDict.subDict("gradSchemes").get<NeoN::TokenList>("limited");
+        fvSchemesDict.subDict("gradSchemes").getVal<NeoN::TokenList>("limited");
     REQUIRE(limitedToken.size() == 4);
     REQUIRE(limitedToken.get<std::string>(0) == "cellLimited");
     REQUIRE(limitedToken.get<std::string>(1) == "Gauss");
     REQUIRE(limitedToken.get<std::string>(2) == "linear");
     REQUIRE(limitedToken.get<NeoN::label>(3) == 1);
 
-    NeoN::TokenList gradU = fvSchemesDict.subDict("gradSchemes").get<NeoN::TokenList>("grad(U)");
+    NeoN::TokenList gradU = fvSchemesDict.subDict("gradSchemes").getVal<NeoN::TokenList>("grad(U)");
     REQUIRE(gradU.size() == 2);
-    REQUIRE(gradU.get<std::string>(0) == "Gauss");
-    REQUIRE(gradU.get<std::string>(1) == "linear");
+    REQUIRE(gradU.getVal<std::string>(0) == "Gauss");
+    REQUIRE(gradU.getVal<std::string>(1) == "linear");
 }
 
 TEST_CASE("read testDictionary from disk")
@@ -77,15 +77,15 @@ TEST_CASE("read testDictionary from disk")
 
     NeoN::Dictionary nfTestDict = NeoFOAM::convert(ofTestDict);
 
-    REQUIRE(nfTestDict.get<NeoN::label>("label") == 1);
-    REQUIRE(nfTestDict.get<NeoN::scalar>("scalar") == 2.1);
-    REQUIRE(nfTestDict.get<NeoN::scalar>("scalar2") == 2.0);
-    REQUIRE(nfTestDict.get<int>("scalarWriteAnsInt") == 2);
-    REQUIRE(nfTestDict.get<NeoN::Vec3>("vector") == NeoN::Vec3(1.0, 2.0, 3.0));
-    REQUIRE(nfTestDict.get<std::string>("word") == "word");
+    REQUIRE(nfTestDict.getVal<NeoN::label>("label") == 1);
+    REQUIRE(nfTestDict.getVal<NeoN::scalar>("scalar") == 2.1);
+    REQUIRE(nfTestDict.getVal<NeoN::scalar>("scalar2") == 2.0);
+    REQUIRE(nfTestDict.getVal<int>("scalarWriteAnsInt") == 2);
+    REQUIRE(nfTestDict.getVal<NeoN::Vec3>("vector") == NeoN::Vec3(1.0, 2.0, 3.0));
+    REQUIRE(nfTestDict.getVal<std::string>("word") == "word");
 
     NeoN::Dictionary& nfSubDict = nfTestDict.subDict("subDict");
-    REQUIRE(nfSubDict.get<NeoN::scalar>("subScalar") == 4.1);
-    REQUIRE(nfSubDict.get<NeoN::Vec3>("subVector") == NeoN::Vec3(5.0, 6.0, 7.0));
-    REQUIRE(nfSubDict.get<std::string>("subWord") == "subWord");
+    REQUIRE(nfSubDict.getVal<NeoN::scalar>("subScalar") == 4.1);
+    REQUIRE(nfSubDict.getVal<NeoN::Vec3>("subVector") == NeoN::Vec3(5.0, 6.0, 7.0));
+    REQUIRE(nfSubDict.getVal<std::string>("subWord") == "subWord");
 }

--- a/tutorials/cylinder2D/system/controlDict
+++ b/tutorials/cylinder2D/system/controlDict
@@ -16,7 +16,7 @@ FoamFile
 
 application     icoFoam;
 
-executor        GPU;
+executor        Serial;
 
 startFrom       startTime;
 

--- a/tutorials/cylinder2D/system/fvSolution
+++ b/tutorials/cylinder2D/system/fvSolution
@@ -36,7 +36,7 @@ solvers
         solver          smoothSolver;
         smoother        symGaussSeidel;
         tolerance       1e-05;
-        relTol          0.0;
+        relTol          0;
     }
 
     UFinal


### PR DESCRIPTION
This PR fixes the issue with the failing badAnyCast. The fix proposed in https://github.com/exasim-project/NeoN/actions/runs/19477256232/job/55829317984?pr=403 slightly changes the use of dictionaries. Now dict.get<T> returns a copy (which allows to convert for example from int to scalar). Most cases we want to access a reference can be handled by dictionary.subDict which returns a reference.