### PR TITLE
Enhance coordinated merge on NeoFOAM and NeoN

### DIFF
--- a/.github/workflows/coordinated-merge.yaml
+++ b/.github/workflows/coordinated-merge.yaml
@@ -79,15 +79,15 @@ jobs:
       - name: Validate NeoFOAM CI (fail fast)
         run: |
           echo "Checking NeoFOAM CI checks for PR $PR_NUMBER in $FOAM_REPO..."
-          checks=$(gh pr checks "$PR_NUMBER" --repo "$FOAM_REPO" --json name,status,conclusion)
-          echo "$checks" | jq -r '.[] | "• \(.name): status=\(.status), conclusion=\(.conclusion)"'
+          checks=$(gh pr checks "$PR_NUMBER" --repo "$FOAM_REPO" --json name,state)
+          echo "$checks" | jq -r '.[] | "• \(.name): state=\(.state)"'
 
           failing=$(echo "$checks" | jq -r '
             .[]
             | select(
-                .conclusion != null
-                and .conclusion != "success"
-                and .conclusion != "skipped"
+                (.name | test("coordinated-merge"; "i") | not)  # exclude coordinated-merge workflow
+                and .state != "SUCCESS"
+                and .state != "SKIPPED"
               )
             | .name
           ')
@@ -98,20 +98,19 @@ jobs:
             exit 1
           fi
 
-          echo "All NeoFOAM CI checks passed (ignoring skipped)."
+          echo "All NeoFOAM CI checks passed (ignoring skipped and excluding coordinated-merge)."
 
       - name: Validate NeoN CI (fail fast)
         run: |
           echo "Checking NeoN CI checks for PR $NEON_PR_NUMBER in $NEON_REPO..."
-          checks=$(gh pr checks "$NEON_PR_NUMBER" --repo "$NEON_REPO" --json name,status,conclusion)
-          echo "$checks" | jq -r '.[] | "• \(.name): status=\(.status), conclusion=\(.conclusion)"'
+          checks=$(gh pr checks "$NEON_PR_NUMBER" --repo "$NEON_REPO" --json name,state)
+          echo "$checks" | jq -r '.[] | "• \(.name): state=\(.state)"'
 
           failing=$(echo "$checks" | jq -r '
             .[]
             | select(
-                .conclusion != null
-                and .conclusion != "success"
-                and .conclusion != "skipped"
+                .state != "SUCCESS"
+                and .state != "SKIPPED"
               )
             | .name
           ')

--- a/.github/workflows/coordinated-merge.yaml
+++ b/.github/workflows/coordinated-merge.yaml
@@ -93,7 +93,7 @@ jobs:
           ')
 
           if [[ -n "$failing" ]]; then
-            echo "NeoFOAM CI has failing checks:"
+            echo "NeoFOAM CI has the following failing checks:"
             echo "$failing"
             exit 1
           fi
@@ -116,7 +116,7 @@ jobs:
           ')
 
           if [[ -n "$failing" ]]; then
-            echo "NeoN CI has failing checks:"
+            echo "NeoN CI has the following failing checks:"
             echo "$failing"
             exit 1
           fi

--- a/.github/workflows/coordinated-merge.yaml
+++ b/.github/workflows/coordinated-merge.yaml
@@ -76,20 +76,53 @@ jobs:
           fi
 
       # CI check validation for both PRs
-      - name: Wait for NeoFOAM CI to pass
+      - name: Validate NeoFOAM CI (fail fast)
         run: |
-          gh pr checks "$PR_NUMBER" --repo $FOAM_REPO --watch
-          status=$(gh pr checks "$PR_NUMBER" --repo $FOAM_REPO --json status -q '.status')
-          [[ "$status" == "SUCCESS" ]] || { echo "NeoFOAM CI failed"; exit 1; }
+          echo "Checking NeoFOAM CI checks for PR $PR_NUMBER in $FOAM_REPO..."
+          checks=$(gh pr checks "$PR_NUMBER" --repo "$FOAM_REPO" --json name,status,conclusion)
+          echo "$checks" | jq -r '.[] | "• \(.name): status=\(.status), conclusion=\(.conclusion)"'
 
-      - name: Wait for NeoN CI to pass
+          failing=$(echo "$checks" | jq -r '
+            .[]
+            | select(
+                .conclusion != null
+                and .conclusion != "success"
+                and .conclusion != "skipped"
+              )
+            | .name
+          ')
+
+          if [[ -n "$failing" ]]; then
+            echo "NeoFOAM CI has failing checks:"
+            echo "$failing"
+            exit 1
+          fi
+
+          echo "All NeoFOAM CI checks passed (ignoring skipped)."
+
+      - name: Validate NeoN CI (fail fast)
         run: |
-          gh pr checks "$NEON_PR_NUMBER" --repo $NEON_REPO --watch
-          status=$(gh pr checks "$NEON_PR_NUMBER" --repo $NEON_REPO --json status -q '.status')
-          [[ "$status" == "SUCCESS" ]] || { echo "NeoN CI failed"; exit 1; }
+          echo "Checking NeoN CI checks for PR $NEON_PR_NUMBER in $NEON_REPO..."
+          checks=$(gh pr checks "$NEON_PR_NUMBER" --repo "$NEON_REPO" --json name,status,conclusion)
+          echo "$checks" | jq -r '.[] | "• \(.name): status=\(.status), conclusion=\(.conclusion)"'
 
-      - name: All CI checks passed
-        run: echo "All checks passed for both PRs."
+          failing=$(echo "$checks" | jq -r '
+            .[]
+            | select(
+                .conclusion != null
+                and .conclusion != "success"
+                and .conclusion != "skipped"
+              )
+            | .name
+          ')
+
+          if [[ -n "$failing" ]]; then
+            echo "NeoN CI has failing checks:"
+            echo "$failing"
+            exit 1
+          fi
+
+          echo "All NeoN CI checks passed (ignoring skipped)."
 
       # Dry-run merges to ensure no conflicts
       - name: Dry-run merges

--- a/.github/workflows/coordinated-merge.yaml
+++ b/.github/workflows/coordinated-merge.yaml
@@ -8,6 +8,7 @@ jobs:
   coordinated-merge:
     if: contains(github.event.pull_request.labels.*.name, 'coordinated-merge')
     runs-on: ubuntu-latest
+
     env:
       GH_TOKEN: ${{ secrets.MERGE_TOKEN }}
       NEON_REPO: exasim-project/NeoN
@@ -15,6 +16,7 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref }}
 
     steps:
+
       - name: Checkout NeoFOAM repository
         uses: actions/checkout@v4
         with:
@@ -69,32 +71,60 @@ jobs:
             exit 1
           fi
 
+      # CHECK ALL WORKFLOWS PASS
+      - name: Wait for & verify NeoFOAM PR checks succeed
+        run: |
+          echo "Waiting for NeoFOAM CI checks to pass..."
+          gh pr checks ${{ github.event.pull_request.number }} --repo $FOAM_REPO --watch
+
+          result=$(gh pr checks ${{ github.event.pull_request.number }} --repo $FOAM_REPO --json status -q '.status')
+          if [[ "$result" != "SUCCESS" ]]; then
+            echo "NeoFOAM CI checks failing."
+            exit 1
+          fi
+
+      - name: Wait for & verify NeoN PR checks succeed
+        run: |
+          neon_pr_number="${{ steps.find-neon.outputs.neon_pr_number }}"
+          echo "Waiting for NeoN CI checks to pass..."
+          gh pr checks "$neon_pr_number" --repo $NEON_REPO --watch
+
+          result=$(gh pr checks "$neon_pr_number" --repo $NEON_REPO --json status -q '.status')
+          if [[ "$result" != "SUCCESS" ]]; then
+            echo "NeoN CI checks failing."
+            exit 1
+          fi
+
+      - name: All CI checks passed
+        run: echo "All workflows passed for both PRs."
+
+      # DRY-RUN MERGE
       - name: Dry-run both merges locally
         run: |
           set -e
-          # Clone both repos into temp dirs
           TMP_DIR=$(mktemp -d)
+
           git clone https://github.com/$FOAM_REPO.git $TMP_DIR/foam
           git clone https://github.com/$NEON_REPO.git $TMP_DIR/neon
 
-          # Configure git identity for merge commits
           git config --global user.email "ci-bot@example.com"
           git config --global user.name "CI Bot"
 
-          # Checkout base branches and dry-run merge NeoFOAM
+          # NeoFOAM dry-run
           cd $TMP_DIR/foam
           git checkout ${{ github.event.pull_request.base.ref }}
           git fetch origin $BRANCH_NAME
           git merge --no-commit --no-ff origin/$BRANCH_NAME || { echo "NeoFOAM merge would fail"; exit 1; }
 
-          # Dry-run merge NeoN
+          # NeoN dry-run
           cd $TMP_DIR/neon
           git checkout ${{ steps.find-neon.outputs.neon_pr_base }}
           git fetch origin $BRANCH_NAME
           git merge --no-commit --no-ff origin/$BRANCH_NAME || { echo "NeoN merge would fail"; exit 1; }
 
-          echo "Dry-run merge succeeded for both PRs."
+          echo "Dry-run merge succeeded."
 
+      # MERGE
       - name: Merge NeoN PR
         run: |
           neon_pr_number="${{ steps.find-neon.outputs.neon_pr_number }}"

--- a/.github/workflows/coordinated-merge.yaml
+++ b/.github/workflows/coordinated-merge.yaml
@@ -14,6 +14,7 @@ jobs:
       NEON_REPO: exasim-project/NeoN
       FOAM_REPO: exasim-project/NeoFOAM
       BRANCH_NAME: ${{ github.head_ref }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
 
     steps:
 
@@ -24,121 +25,112 @@ jobs:
 
       - name: Confirm triggering context
         run: |
-          echo "Triggered from NeoFOAM PR: #${{ github.event.pull_request.number }}"
+          echo "Triggered from NeoFOAM PR: #$PR_NUMBER"
           echo "Branch name: $BRANCH_NAME"
-          echo "Label: coordinated-merge detected"
-          echo "NeoFOAM PR base branch: ${{ github.event.pull_request.base.ref }}"
+          echo "Base branch: ${{ github.event.pull_request.base.ref }}"
 
       - name: Check NeoFOAM PR approval
         run: |
-          approved=$(gh pr view ${{ github.event.pull_request.number }} --repo $FOAM_REPO --json reviewDecision -q '.reviewDecision')
+          approved=$(gh pr view "$PR_NUMBER" --repo $FOAM_REPO --json reviewDecision -q '.reviewDecision')
           if [[ "$approved" != "APPROVED" ]]; then
-            echo "NeoFOAM PR not yet approved."
+            echo "NeoFOAM PR not approved."
             exit 1
           fi
 
+      # Find matching NeoN PR
       - name: Find NeoN PR with same branch
         id: find-neon
         run: |
-          neon_pr=$(gh pr list --repo $NEON_REPO --head $BRANCH_NAME --json number,baseRefName -q '.[0]')
-          if [[ -z "$neon_pr" ]]; then
-            echo "No matching NeoN PR found for branch '$BRANCH_NAME'."
+          neon=$(gh pr list --repo "$NEON_REPO" --head "$BRANCH_NAME" --json number,baseRefName -q '.[0]')
+          if [[ -z "$neon" ]]; then
+            echo "No matching NeoN PR found for branch $BRANCH_NAME"
             exit 1
           fi
 
-          neon_pr_number=$(echo $neon_pr | jq -r '.number')
-          neon_pr_base=$(echo $neon_pr | jq -r '.baseRefName')
+          echo "$neon" > neon.json
+          echo "NEON_PR_NUMBER=$(jq -r '.number' neon.json)" >> $GITHUB_ENV
+          echo "NEON_BASE_BRANCH=$(jq -r '.baseRefName' neon.json)" >> $GITHUB_ENV
 
-          echo "neon_pr_number=$neon_pr_number" >> $GITHUB_OUTPUT
-          echo "neon_pr_base=$neon_pr_base" >> $GITHUB_OUTPUT
+      - name: Print NeoN PR information
+        run: |
+          echo "NeoN PR number: $NEON_PR_NUMBER"
+          echo "NeoN base branch: $NEON_BASE_BRANCH"
 
       - name: Verify base branches match
         run: |
-          foam_base="${{ github.event.pull_request.base.ref }}"
-          neon_base="${{ steps.find-neon.outputs.neon_pr_base }}"
+          FOAM_BASE="${{ github.event.pull_request.base.ref }}"
 
-          if [[ "$foam_base" != "$neon_base" ]]; then
-            echo "Base branches do not match. Cannot perform coordinated merge."
+          if [[ "$FOAM_BASE" != "$NEON_BASE_BRANCH" ]]; then
+            echo "Base branches do not match."
+            echo "NeoFOAM base: $FOAM_BASE"
+            echo "NeoN base:    $NEON_BASE_BRANCH"
             exit 1
           fi
 
       - name: Check NeoN PR approval
         run: |
-          neon_pr_number="${{ steps.find-neon.outputs.neon_pr_number }}"
-          approved=$(gh pr view "$neon_pr_number" --repo $NEON_REPO --json reviewDecision -q '.reviewDecision')
+          approved=$(gh pr view "$NEON_PR_NUMBER" --repo $NEON_REPO --json reviewDecision -q '.reviewDecision')
           if [[ "$approved" != "APPROVED" ]]; then
-            echo "NeoN PR not yet approved."
+            echo "NeoN PR not approved."
             exit 1
           fi
 
-      # CHECK ALL WORKFLOWS PASS
-      - name: Wait for & verify NeoFOAM PR checks succeed
+      # CI check validation for both PRs
+      - name: Wait for NeoFOAM CI to pass
         run: |
-          echo "Waiting for NeoFOAM CI checks to pass..."
-          gh pr checks ${{ github.event.pull_request.number }} --repo $FOAM_REPO --watch
+          gh pr checks "$PR_NUMBER" --repo $FOAM_REPO --watch
+          status=$(gh pr checks "$PR_NUMBER" --repo $FOAM_REPO --json status -q '.status')
+          [[ "$status" == "SUCCESS" ]] || { echo "NeoFOAM CI failed"; exit 1; }
 
-          result=$(gh pr checks ${{ github.event.pull_request.number }} --repo $FOAM_REPO --json status -q '.status')
-          if [[ "$result" != "SUCCESS" ]]; then
-            echo "NeoFOAM CI checks failing."
-            exit 1
-          fi
-
-      - name: Wait for & verify NeoN PR checks succeed
+      - name: Wait for NeoN CI to pass
         run: |
-          neon_pr_number="${{ steps.find-neon.outputs.neon_pr_number }}"
-          echo "Waiting for NeoN CI checks to pass..."
-          gh pr checks "$neon_pr_number" --repo $NEON_REPO --watch
-
-          result=$(gh pr checks "$neon_pr_number" --repo $NEON_REPO --json status -q '.status')
-          if [[ "$result" != "SUCCESS" ]]; then
-            echo "NeoN CI checks failing."
-            exit 1
-          fi
+          gh pr checks "$NEON_PR_NUMBER" --repo $NEON_REPO --watch
+          status=$(gh pr checks "$NEON_PR_NUMBER" --repo $NEON_REPO --json status -q '.status')
+          [[ "$status" == "SUCCESS" ]] || { echo "NeoN CI failed"; exit 1; }
 
       - name: All CI checks passed
-        run: echo "All workflows passed for both PRs."
+        run: echo "All checks passed for both PRs."
 
-      # DRY-RUN MERGE
-      - name: Dry-run both merges locally
+      # Dry-run merges to ensure no conflicts
+      - name: Dry-run merges
         run: |
           set -e
-          TMP_DIR=$(mktemp -d)
+          TMP=$(mktemp -d)
 
-          git clone https://github.com/$FOAM_REPO.git $TMP_DIR/foam
-          git clone https://github.com/$NEON_REPO.git $TMP_DIR/neon
+          git clone https://github.com/$FOAM_REPO.git "$TMP/foam"
+          git clone https://github.com/$NEON_REPO.git "$TMP/neon"
 
-          git config --global user.email "ci-bot@example.com"
           git config --global user.name "CI Bot"
+          git config --global user.email "ci-bot@example.com"
 
-          # NeoFOAM dry-run
-          cd $TMP_DIR/foam
-          git checkout ${{ github.event.pull_request.base.ref }}
-          git fetch origin $BRANCH_NAME
-          git merge --no-commit --no-ff origin/$BRANCH_NAME || { echo "NeoFOAM merge would fail"; exit 1; }
+          # NeoFOAM merge simulation
+          cd "$TMP/foam"
+          git checkout "${{ github.event.pull_request.base.ref }}"
+          git fetch origin "$BRANCH_NAME"
+          git merge --no-commit --no-ff origin/"$BRANCH_NAME"
 
-          # NeoN dry-run
-          cd $TMP_DIR/neon
-          git checkout ${{ steps.find-neon.outputs.neon_pr_base }}
-          git fetch origin $BRANCH_NAME
-          git merge --no-commit --no-ff origin/$BRANCH_NAME || { echo "NeoN merge would fail"; exit 1; }
+          # NeoN merge simulation
+          cd "$TMP/neon"
+          git checkout "$NEON_BASE_BRANCH"
+          git fetch origin "$BRANCH_NAME"
+          git merge --no-commit --no-ff origin/"$BRANCH_NAME"
 
-          echo "Dry-run merge succeeded."
+          echo "Dry-run succeeded."
 
-      # MERGE
+      # Merge both PRs
       - name: Merge NeoN PR
         run: |
-          neon_pr_number="${{ steps.find-neon.outputs.neon_pr_number }}"
-          gh pr merge "$neon_pr_number" \
+          gh pr merge "$NEON_PR_NUMBER" \
             --repo $NEON_REPO \
             --merge \
             --admin
 
       - name: Merge NeoFOAM PR
         run: |
-          gh pr merge ${{ github.event.pull_request.number }} \
+          gh pr merge "$PR_NUMBER" \
             --repo $FOAM_REPO \
             --merge \
             --admin
 
       - name: Done
-        run: echo "Coordinated merge completed successfully."
+        run: echo "Coordinated merge completed."

--- a/.github/workflows/coordinated-merge.yaml
+++ b/.github/workflows/coordinated-merge.yaml
@@ -2,7 +2,7 @@ name: Coordinated Merge for NeoFOAM + NeoN
 
 on:
   pull_request:
-    types: [labeled, unlabeled, synchronize, reopened, opened]
+    types: [labeled, synchronize]
 
 jobs:
   coordinated-merge:

--- a/.github/workflows/coordinated-merge.yaml
+++ b/.github/workflows/coordinated-merge.yaml
@@ -29,13 +29,6 @@ jobs:
           echo "Branch name: $BRANCH_NAME"
           echo "Base branch: ${{ github.event.pull_request.base.ref }}"
 
-      - name: Check NeoFOAM PR approval
-        run: |
-          approved=$(gh pr view "$PR_NUMBER" --repo $FOAM_REPO --json reviewDecision -q '.reviewDecision')
-          if [[ "$approved" != "APPROVED" ]]; then
-            echo "NeoFOAM PR not approved."
-            exit 1
-          fi
 
       # Find matching NeoN PR
       - name: Find NeoN PR with same branch
@@ -75,7 +68,38 @@ jobs:
             exit 1
           fi
 
+      - name: Check NeoFOAM PR approval
+        run: |
+          approved=$(gh pr view "$PR_NUMBER" --repo $FOAM_REPO --json reviewDecision -q '.reviewDecision')
+          if [[ "$approved" != "APPROVED" ]]; then
+            echo "NeoFOAM PR not approved."
+            exit 1
+          fi
+
       # CI check validation for both PRs
+      - name: Validate NeoN CI (fail fast)
+        run: |
+          echo "Checking NeoN CI checks for PR $NEON_PR_NUMBER in $NEON_REPO..."
+          checks=$(gh pr checks "$NEON_PR_NUMBER" --repo "$NEON_REPO" --json name,state)
+          echo "$checks" | jq -r '.[] | "• \(.name): state=\(.state)"'
+
+          failing=$(echo "$checks" | jq -r '
+            .[]
+            | select(
+                .state != "SUCCESS"
+                and .state != "SKIPPED"
+              )
+            | .name
+          ')
+
+          if [[ -n "$failing" ]]; then
+            echo "NeoN CI has the following failing checks:"
+            echo "$failing"
+            exit 1
+          fi
+
+          echo "All NeoN CI checks passed (ignoring skipped)."
+
       - name: Validate NeoFOAM CI (fail fast)
         run: |
           echo "Checking NeoFOAM CI checks for PR $PR_NUMBER in $FOAM_REPO..."
@@ -100,29 +124,6 @@ jobs:
 
           echo "All NeoFOAM CI checks passed (ignoring skipped and excluding coordinated-merge)."
 
-      - name: Validate NeoN CI (fail fast)
-        run: |
-          echo "Checking NeoN CI checks for PR $NEON_PR_NUMBER in $NEON_REPO..."
-          checks=$(gh pr checks "$NEON_PR_NUMBER" --repo "$NEON_REPO" --json name,state)
-          echo "$checks" | jq -r '.[] | "• \(.name): state=\(.state)"'
-
-          failing=$(echo "$checks" | jq -r '
-            .[]
-            | select(
-                .state != "SUCCESS"
-                and .state != "SKIPPED"
-              )
-            | .name
-          ')
-
-          if [[ -n "$failing" ]]; then
-            echo "NeoN CI has the following failing checks:"
-            echo "$failing"
-            exit 1
-          fi
-
-          echo "All NeoN CI checks passed (ignoring skipped)."
-
       # Dry-run merges to ensure no conflicts
       - name: Dry-run merges
         run: |
@@ -135,15 +136,15 @@ jobs:
           git config --global user.name "CI Bot"
           git config --global user.email "ci-bot@example.com"
 
-          # NeoFOAM merge simulation
-          cd "$TMP/foam"
-          git checkout "${{ github.event.pull_request.base.ref }}"
-          git fetch origin "$BRANCH_NAME"
-          git merge --no-commit --no-ff origin/"$BRANCH_NAME"
-
           # NeoN merge simulation
           cd "$TMP/neon"
           git checkout "$NEON_BASE_BRANCH"
+          git fetch origin "$BRANCH_NAME"
+          git merge --no-commit --no-ff origin/"$BRANCH_NAME"
+
+          # NeoFOAM merge simulation
+          cd "$TMP/foam"
+          git checkout "${{ github.event.pull_request.base.ref }}"
           git fetch origin "$BRANCH_NAME"
           git merge --no-commit --no-ff origin/"$BRANCH_NAME"
 

--- a/README.md
+++ b/README.md
@@ -31,3 +31,5 @@ The repository is structured in the following way:
 - *tests* demonstrating that NeoFOAM and OpenFOAM deliver identical results are provided by this repository in the test folder.
 - *examples* provides examples of how NeoFOAM can be used for writing applications
 - *tutorials* provides tutorial cases which can be run like typical OpenFOAM cases
+
+### Test Coordinated Merge

--- a/README.md
+++ b/README.md
@@ -31,5 +31,3 @@ The repository is structured in the following way:
 - *tests* demonstrating that NeoFOAM and OpenFOAM deliver identical results are provided by this repository in the test folder.
 - *examples* provides examples of how NeoFOAM can be used for writing applications
 - *tutorials* provides tutorial cases which can be run like typical OpenFOAM cases
-
-### Test Coordinated Merge


### PR DESCRIPTION
The current version of coordinated merge only checks if the two PRs of interest get approved before merging.
But sometimes a PR can get approved before it passes all CI checks. 

It means that the two PRs will be merged together automatically via coordinated merge even if some CI checks fail.
The consequence is that the merged PRs might not be actually finished and can break the code.

To avoid such situation, this PR enhance the GitHub workflow of coordinated merge by adding two checks which confirm that the two PRs of interest have passed all the required CI checks before merging.

In addition, the GitHub workflow is refactored to be more concise and more readable.