### PR TITLE
Make the GitHub workflow of building NeoFOAM to use the correct NeoN's branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -81,18 +81,18 @@ jobs:
 
       - name: Build NeoFOAM
         run: |
-          source /usr/lib/openfoam/openfoam2406/etc/bashrc
-          CC=${{ matrix.compiler.CC }} \
-          CXX=${{ matrix.compiler.CXX }} \
-          cmake --preset develop \
-            -DNeoN_DEVEL_TOOLS=OFF \
-            -DNeoN_BUILD_TESTS=OFF \
-            -DNEOFOAM_BUILD_BENCHMARKS=OFF \
-            -DNeoN_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF \
-            -DNEOFOAM_NEON_VERSION=${{ env.NEON_BRANCH }}
-          cmake --build --preset develop
+          bash -l -c "source /usr/lib/openfoam/openfoam2406/etc/bashrc \
+                && CC=${{ matrix.compiler.CC }} \
+                   CXX=${{ matrix.compiler.CXX }} \
+                   cmake --preset develop \
+                   -DNeoN_DEVEL_TOOLS=OFF \
+                   -DNeoN_BUILD_TESTS=OFF \
+                   -DNEOFOAM_BUILD_BENCHMARKS=OFF \
+                   -DNeoN_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF \
+                   -DNEOFOAM_NEON_VERSION=${{ env.NEON_BRANCH }} \
+                && cmake --build --preset develop"
 
       - name: Execute unit tests of NeoFOAM
         run: |
-          source /usr/lib/openfoam/openfoam2406/etc/bashrc
-          ctest --preset develop
+          bash -l -c "source /usr/lib/openfoam/openfoam2406/etc/bashrc \
+                && ctest --preset develop"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,22 +80,17 @@ jobs:
           cmake --version
 
       - name: Build NeoFOAM
-        working-directory: ${{ github.workspace }}
         run: |
-          bash -l -c "source /usr/lib/openfoam/openfoam2406/etc/bashrc \
-                && CC=${{ matrix.compiler.CC }} \
-                && CXX=${{ matrix.compiler.CXX }} \
-                && cmake --preset develop \
-                   -DNeoN_DEVEL_TOOLS=OFF \
-                   -DNeoN_BUILD_TESTS=OFF \
-                   -DNEOFOAM_BUILD_BENCHMARKS=OFF \
-                   -DNeoN_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF \
-                   -DNEOFOAM_NEON_VERSION=${{ env.NEON_BRANCH }} \
-                && cmake --build --preset develop"
+          source /usr/lib/openfoam/openfoam2406/etc/bashrc || true
+          CC=${{matrix.compiler.CC}} \
+          CXX=${{matrix.compiler.CXX}} \
+          cmake --preset develop \
+            -DNEOFOAM_DEVEL_TOOLS=OFF \
+            -DNEOFOAM_BUILD_BENCHMARKS=OFF \
+            -DNEOFOAM_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF
+          cmake --build  --preset develop
 
-
-      - name: Execute unit tests of NeoFOAM
-        working-directory: ${{ github.workspace }}
+      - name: Execute unit tests NeoFOAM
         run: |
-          bash -l -c "source /usr/lib/openfoam/openfoam2406/etc/bashrc \
-                && ctest --preset develop"
+          source /usr/lib/openfoam/openfoam2406/etc/bashrc || true
+          ctest --preset develop

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,16 +79,8 @@ jobs:
           ninja --version
           cmake --version
 
-      # ensures OpenFOAM is available for all following steps
-      - name: Source OpenFOAM environment
-        id: openfoam
-        run: |
-          echo "Sourcing OpenFOAM..."
-          source /usr/lib/openfoam/openfoam2406/etc/bashrc
-          echo "OPENFOAM_READY=1" >> "$GITHUB_ENV"
-
       - name: Build NeoFOAM
-        if: env.OPENFOAM_READY == '1' 
+        if: env.OPENFOAM_READY == '1'
         run: |
           source /usr/lib/openfoam/openfoam2406/etc/bashrc
           CC=${{ matrix.compiler.CC }} \
@@ -101,8 +93,8 @@ jobs:
             -DNEOFOAM_NEON_VERSION=${{ env.NEON_BRANCH }}
           cmake --build --preset develop
 
-      - name: Execute unit tests NeoFOAM
-        if: env.OPENFOAM_READY == '1' 
+      - name: Execute unit tests of NeoFOAM
+        if: env.OPENFOAM_READY == '1'
         run: |
           source /usr/lib/openfoam/openfoam2406/etc/bashrc
           ctest --preset develop

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,13 +1,14 @@
 name: Build NeoFOAM
-run-name: 'Build workflow'
+run-name: 'Build NeoFOAM
 
 on:
   push:
-    branches:
-      - develop
-      - main
+    branches: [develop, main]
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
+  schedule:
+    - cron: '00 8 * * 0'
+  workflow_dispatch:
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
@@ -19,9 +20,8 @@ concurrency:
 
 jobs:
   build-neofoam:
-    name: Build NeoFOAM
-    runs-on: ubuntu-latest
     if: "!contains(toJson(github.event.pull_request.labels.*.name), 'Skip-build')"
+    name: Build NeoFOAM
     strategy:
       fail-fast: false
       matrix:
@@ -30,53 +30,50 @@ jobs:
             CXX: clang++
           - CC: gcc
             CXX: g++
-
+    runs-on: ubuntu-24.04
     steps:
-      # Checkout NeoFOAM
-      - name: Checkout NeoFOAM repository
-        uses: actions/checkout@v4
-
-      # Determine NeoN branch (safe for slashes)
-      - name: Determine NeoN branch
-        id: neon_branch
+      - name: Determine branch
         run: |
-          TARGET_BRANCH="${{ github.ref_name }}"
-          echo "Checking if NeoN branch '$TARGET_BRANCH' exists..."
 
-          if git ls-remote --heads https://github.com/exasim-project/NeoN "$TARGET_BRANCH" | grep -q "^.*$TARGET_BRANCH$"; then
-            echo "Branch exists. Using $TARGET_BRANCH"
-            printf "branch=%s\n" "$TARGET_BRANCH" >> "$GITHUB_OUTPUT"
+          # Detect current branch of NeoFOAM
+          NEOFOAM_BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+          echo "Using NeoFOAM branch: $NEOFOAM_BRANCH"
+          echo "NEOFOAM_BRANCH=$NEOFOAM_BRANCH" >> $GITHUB_ENV
+
+          # Define remote repo URL
+          REPO_URL="https://github.com/exasim-project/NeoN"
+
+          echo "Checking if branch '$NEOFOAM_BRANCH' exists in NeoN..."
+
+          # Query exact match: refs/heads/<branch>
+          if git ls-remote --exit-code --heads "$REPO_URL" "refs/heads/${NEOFOAM_BRANCH}" >/dev/null 2>&1; then
+            echo "NeoN branch exists: $NEOFOAM_BRANCH"
+            echo "NEON_BRANCH=$NEOFOAM_BRANCH" >> $GITHUB_ENV
           else
-            echo "Branch does NOT exist. Falling back to develop"
-            printf "branch=develop\n" >> "$GITHUB_OUTPUT"
+            echo "NeoN branch '$NEOFOAM_BRANCH' does not exist. Falling back to 'develop'."
+            echo "NEON_BRANCH=develop" >> $GITHUB_ENV
+          fi
 
-      # Checkout NeoN
-      - name: Checkout NeoN repository
+      - name: Checkout NeoN
         uses: actions/checkout@v4
         with:
           repository: exasim-project/NeoN
-          path: NeoN
-          ref: ${{ steps.neon_branch.outputs.branch }}
+          ref: ${{ env.NEON_BRANCH }}
+          fetch-depth: 1
 
-      # Log & validate NeoN directory
-      - name: Validate NeoN checkout
-        run: |
-          NEON_DIR="${{ github.workspace }}/NeoN"
-          echo "NeoN will be used from: $NEON_DIR"
-          echo "NeoN branch: ${{ steps.neon_branch.outputs.branch }}"
+      # Optional NeoN checkout if needed
+      # - name: Checkout NeoN submodule
+      #   uses: actions/checkout@v4
+      #   with:
+      #     repository: exasim-project/NeoN
+      #     path: NeoN
+      #     ref: '${{ env.NEON_BRANCH }}'
 
-          if [ ! -d "$NEON_DIR" ]; then
-            echo "Error: NeoN directory '$NEON_DIR' does not exist!"
-            exit 1
-          fi
-
-      # Setup OpenFOAM
       - name: Set up OpenFOAM
         uses: gerlero/setup-openfoam@v1
         with:
           openfoam-version: 2406
 
-      # Install dependencies
       - name: Install dependencies
         uses: gerlero/apt-install@v1
         with:
@@ -91,28 +88,26 @@ jobs:
             libopenmpi-dev
             openmpi-bin
 
-      # Get tool versions
       - name: Get versions
         run: |
           clang --version
           ninja --version
           cmake --version
 
-      # Build NeoFOAM
       - name: Build NeoFOAM
         run: |
           source /usr/lib/openfoam/openfoam2406/etc/bashrc || true
-          CC=${{matrix.compiler.CC}} \
-          CXX=${{matrix.compiler.CXX}} \
+          CC=${{ matrix.compiler.CC }} \
+          CXX=${{ matrix.compiler.CXX }} \
           cmake --preset develop \
-            -DNEOFOAM_DEVEL_TOOLS=OFF \
+            -DNeoN_DEVEL_TOOLS=OFF \
+            -DNeoN_BUILD_TESTS=OFF \
             -DNEOFOAM_BUILD_BENCHMARKS=OFF \
-            -DNEOFOAM_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF \
-            -DNEOFOAM_NEON_DIR="${{ github.workspace }}/NeoN"
+            -DNeoN_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF \
+            -DNEOFOAM_NEON_VERSION=${{ env.NEON_BRANCH }}
           cmake --build --preset develop
 
-      # Execute unit tests
-      - name: Execute unit tests NeoFOAM
+      - name: Execute unit tests NeoN
         run: |
           source /usr/lib/openfoam/openfoam2406/etc/bashrc || true
           ctest --preset develop

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -81,14 +81,15 @@ jobs:
 
       - name: Build NeoFOAM
         run: |
-          source /usr/lib/openfoam/openfoam2406/etc/bashrc || true
+          cd $GITHUB_WORKSPACE
+          source /usr/lib/openfoam/openfoam2406/etc/bashrc
           CC=${{matrix.compiler.CC}} \
           CXX=${{matrix.compiler.CXX}} \
           cmake --preset develop \
             -DNEOFOAM_DEVEL_TOOLS=OFF \
             -DNEOFOAM_BUILD_BENCHMARKS=OFF \
             -DNEOFOAM_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF
-          cmake --build  --preset develop
+          cmake --build --preset develop
 
       - name: Execute unit tests NeoFOAM
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-neofoam:
     name: Build NeoFOAM
     runs-on: ubuntu-latest
     if: "!contains(toJson(github.event.pull_request.labels.*.name), 'Skip-build')"
@@ -30,47 +30,89 @@ jobs:
             CXX: clang++
           - CC: gcc
             CXX: g++
+
     steps:
-     - name: Checkout to repository
-       uses: actions/checkout@v4
+      # Checkout NeoFOAM
+      - name: Checkout NeoFOAM repository
+        uses: actions/checkout@v4
 
-     - name: Set up OpenFOAM
-       uses: gerlero/setup-openfoam@v1
-       with:
-         openfoam-version: 2406
+      # Determine NeoN branch
+      - name: Determine NeoN branch
+        id: neon_branch
+        run: |
+          TARGET_BRANCH="${{ github.ref_name }}"
+          echo "Checking if NeoN branch '$TARGET_BRANCH' exists..."
 
-     - name: Install dependencies
-       uses: gerlero/apt-install@v1
-       with:
-         packages: >-
-           ninja-build
-           clang-16
-           gcc-10
-           libomp-16-dev
-           python3
-           python3-dev
-           build-essential
-           libopenmpi-dev
-           openmpi-bin
+          if git ls-remote --heads https://github.com/exasim-project/NeoN "$TARGET_BRANCH" | grep "$TARGET_BRANCH" ; then
+            echo "Branch exists. Using $TARGET_BRANCH"
+            echo "branch=$TARGET_BRANCH" >> $GITHUB_OUTPUT
+          else
+            echo "Branch does NOT exist. Falling back to develop"
+            echo "branch=develop" >> $GITHUB_OUTPUT
 
-     - name: Get versions
-       run: |
-         clang --version
-         ninja --version
-         cmake --version
+      # Checkout NeoN
+      - name: Checkout NeoN repository
+        uses: actions/checkout@v4
+        with:
+          repository: exasim-project/NeoN
+          path: NeoN
+          ref: ${{ steps.neon_branch.outputs.branch }}
 
-     - name: Build NeoFOAM
-       run: |
-         source /usr/lib/openfoam/openfoam2406/etc/bashrc || true
-         CC=${{matrix.compiler.CC}} \
-         CXX=${{matrix.compiler.CXX}} \
-         cmake --preset develop \
-           -DNEOFOAM_DEVEL_TOOLS=OFF \
-           -DNEOFOAM_BUILD_BENCHMARKS=OFF \
-           -DNEOFOAM_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF
-         cmake --build  --preset develop
+      # Log & validate NeoN directory
+      - name: Validate NeoN checkout
+        run: |
+          NEON_DIR="${{ github.workspace }}/NeoN"
+          echo "NeoN will be used from: $NEON_DIR"
+          echo "NeoN branch: ${{ steps.neon_branch.outputs.branch }}"
 
-     - name: Execute unit tests NeoFOAM
-       run: |
-         source /usr/lib/openfoam/openfoam2406/etc/bashrc || true
-         ctest --preset develop
+          if [ ! -d "$NEON_DIR" ]; then
+            echo "Error: NeoN directory '$NEON_DIR' does not exist!"
+            exit 1
+          fi
+
+      # Setup OpenFOAM
+      - name: Set up OpenFOAM
+        uses: gerlero/setup-openfoam@v1
+        with:
+          openfoam-version: 2406
+
+      # Install dependencies
+      - name: Install dependencies
+        uses: gerlero/apt-install@v1
+        with:
+          packages: >-
+            ninja-build
+            clang-16
+            gcc-10
+            libomp-16-dev
+            python3
+            python3-dev
+            build-essential
+            libopenmpi-dev
+            openmpi-bin
+
+      # Get tool versions
+      - name: Get versions
+        run: |
+          clang --version
+          ninja --version
+          cmake --version
+
+      # Build NeoFOAM
+      - name: Build NeoFOAM
+        run: |
+          source /usr/lib/openfoam/openfoam2406/etc/bashrc || true
+          CC=${{matrix.compiler.CC}} \
+          CXX=${{matrix.compiler.CXX}} \
+          cmake --preset develop \
+            -DNEOFOAM_NEON_DIR="${{ github.workspace }}/NeoN" \
+            -DNEOFOAM_DEVEL_TOOLS=OFF \
+            -DNEOFOAM_BUILD_BENCHMARKS=OFF \
+            -DNEOFOAM_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF
+          cmake --build --preset develop
+
+      # Execute unit tests
+      - name: Execute unit tests NeoFOAM
+        run: |
+          source /usr/lib/openfoam/openfoam2406/etc/bashrc || true
+          ctest --preset develop

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,7 +80,6 @@ jobs:
           cmake --version
 
       - name: Build NeoFOAM
-        if: env.OPENFOAM_READY == '1'
         run: |
           source /usr/lib/openfoam/openfoam2406/etc/bashrc
           CC=${{ matrix.compiler.CC }} \
@@ -94,7 +93,6 @@ jobs:
           cmake --build --preset develop
 
       - name: Execute unit tests of NeoFOAM
-        if: env.OPENFOAM_READY == '1'
         run: |
           source /usr/lib/openfoam/openfoam2406/etc/bashrc
           ctest --preset develop

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,6 +54,13 @@ jobs:
             echo "NEON_BRANCH=develop" >> $GITHUB_ENV
           fi
 
+      - name: Checkout NeoFOAM
+        uses: actions/checkout@v4
+        with:
+          repository: exasim-project/NeoFOAM
+          ref: ${{ env.NEOFOAM_BRANCH }}
+          fetch-depth: 1
+
       - name: Set up OpenFOAM
         uses: gerlero/setup-openfoam@v1
         with:
@@ -81,7 +88,6 @@ jobs:
 
       - name: Build NeoFOAM
         run: |
-          cd $GITHUB_WORKSPACE
           source /usr/lib/openfoam/openfoam2406/etc/bashrc || true
           CC=${{matrix.compiler.CC}}
           CXX=${{matrix.compiler.CXX}}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,19 +36,19 @@ jobs:
       - name: Checkout NeoFOAM repository
         uses: actions/checkout@v4
 
-      # Determine NeoN branch
+      # Determine NeoN branch (safe for slashes)
       - name: Determine NeoN branch
         id: neon_branch
         run: |
           TARGET_BRANCH="${{ github.ref_name }}"
           echo "Checking if NeoN branch '$TARGET_BRANCH' exists..."
 
-          if git ls-remote --heads https://github.com/exasim-project/NeoN "$TARGET_BRANCH" | grep "$TARGET_BRANCH" ; then
+          if git ls-remote --heads https://github.com/exasim-project/NeoN "$TARGET_BRANCH" | grep -q "^.*$TARGET_BRANCH$"; then
             echo "Branch exists. Using $TARGET_BRANCH"
-            echo "branch=$TARGET_BRANCH" >> $GITHUB_OUTPUT
+            printf "branch=%s\n" "$TARGET_BRANCH" >> "$GITHUB_OUTPUT"
           else
             echo "Branch does NOT exist. Falling back to develop"
-            echo "branch=develop" >> $GITHUB_OUTPUT
+            printf "branch=develop\n" >> "$GITHUB_OUTPUT"
 
       # Checkout NeoN
       - name: Checkout NeoN repository
@@ -105,10 +105,10 @@ jobs:
           CC=${{matrix.compiler.CC}} \
           CXX=${{matrix.compiler.CXX}} \
           cmake --preset develop \
-            -DNEOFOAM_NEON_DIR="${{ github.workspace }}/NeoN" \
             -DNEOFOAM_DEVEL_TOOLS=OFF \
             -DNEOFOAM_BUILD_BENCHMARKS=OFF \
-            -DNEOFOAM_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF
+            -DNEOFOAM_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF \
+            -DNEOFOAM_NEON_DIR="${{ github.workspace }}/NeoN"
           cmake --build --preset develop
 
       # Execute unit tests

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,21 +54,6 @@ jobs:
             echo "NEON_BRANCH=develop" >> $GITHUB_ENV
           fi
 
-      - name: Checkout NeoN
-        uses: actions/checkout@v4
-        with:
-          repository: exasim-project/NeoN
-          ref: ${{ env.NEON_BRANCH }}
-          fetch-depth: 1
-
-      # Optional NeoN checkout if needed
-      # - name: Checkout NeoN submodule
-      #   uses: actions/checkout@v4
-      #   with:
-      #     repository: exasim-project/NeoN
-      #     path: NeoN
-      #     ref: '${{ env.NEON_BRANCH }}'
-
       - name: Set up OpenFOAM
         uses: gerlero/setup-openfoam@v1
         with:
@@ -94,9 +79,18 @@ jobs:
           ninja --version
           cmake --version
 
-      - name: Build NeoFOAM
+      # ensures OpenFOAM is available for all following steps
+      - name: Source OpenFOAM environment
+        id: openfoam
         run: |
-          source /usr/lib/openfoam/openfoam2406/etc/bashrc || true
+          echo "Sourcing OpenFOAM..."
+          source /usr/lib/openfoam/openfoam2406/etc/bashrc
+          echo "OPENFOAM_READY=1" >> "$GITHUB_ENV"
+
+      - name: Build NeoFOAM
+        if: env.OPENFOAM_READY == '1' 
+        run: |
+          source /usr/lib/openfoam/openfoam2406/etc/bashrc
           CC=${{ matrix.compiler.CC }} \
           CXX=${{ matrix.compiler.CXX }} \
           cmake --preset develop \
@@ -108,6 +102,7 @@ jobs:
           cmake --build --preset develop
 
       - name: Execute unit tests NeoFOAM
+        if: env.OPENFOAM_READY == '1' 
         run: |
-          source /usr/lib/openfoam/openfoam2406/etc/bashrc || true
+          source /usr/lib/openfoam/openfoam2406/etc/bashrc
           ctest --preset develop

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,8 +83,8 @@ jobs:
         run: |
           bash -l -c "source /usr/lib/openfoam/openfoam2406/etc/bashrc \
                 && CC=${{ matrix.compiler.CC }} \
-                   CXX=${{ matrix.compiler.CXX }} \
-                   cmake --preset develop \
+                && CXX=${{ matrix.compiler.CXX }} \
+                && cmake --preset develop \
                    -DNeoN_DEVEL_TOOLS=OFF \
                    -DNeoN_BUILD_TESTS=OFF \
                    -DNEOFOAM_BUILD_BENCHMARKS=OFF \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -94,12 +94,11 @@ jobs:
           cmake --preset develop \
             -DNeoN_DEVEL_TOOLS=OFF \
             -DNeoN_BUILD_TESTS=OFF \
-            -DNEOFOAM_BUILD_BENCHMARKS=OFF \
             -DNeoN_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF \
             -DNEOFOAM_NEON_VERSION=${{ env.NEON_BRANCH }}
           cmake --build --preset develop
 
-      - name: Execute unit tests NeoFOAM
+      - name: Execute unit tests of NeoFOAM
         run: |
           source /usr/lib/openfoam/openfoam2406/etc/bashrc || true
           ctest --preset develop

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,6 +80,7 @@ jobs:
           cmake --version
 
       - name: Build NeoFOAM
+        working-directory: ${{ github.workspace }}
         run: |
           bash -l -c "source /usr/lib/openfoam/openfoam2406/etc/bashrc \
                 && CC=${{ matrix.compiler.CC }} \
@@ -92,7 +93,9 @@ jobs:
                    -DNEOFOAM_NEON_VERSION=${{ env.NEON_BRANCH }} \
                 && cmake --build --preset develop"
 
+
       - name: Execute unit tests of NeoFOAM
+        working-directory: ${{ github.workspace }}
         run: |
           bash -l -c "source /usr/lib/openfoam/openfoam2406/etc/bashrc \
                 && ctest --preset develop"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,13 +82,15 @@ jobs:
       - name: Build NeoFOAM
         run: |
           cd $GITHUB_WORKSPACE
-          source /usr/lib/openfoam/openfoam2406/etc/bashrc
-          CC=${{matrix.compiler.CC}} \
-          CXX=${{matrix.compiler.CXX}} \
+          source /usr/lib/openfoam/openfoam2406/etc/bashrc || true
+          CC=${{matrix.compiler.CC}}
+          CXX=${{matrix.compiler.CXX}}
           cmake --preset develop \
-            -DNEOFOAM_DEVEL_TOOLS=OFF \
+            -DNeoN_DEVEL_TOOLS=OFF \
+            -DNeoN_BUILD_TESTS=OFF \
             -DNEOFOAM_BUILD_BENCHMARKS=OFF \
-            -DNEOFOAM_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF
+            -DNeoN_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF \
+            -DNEOFOAM_NEON_VERSION=${{ env.NEON_BRANCH }}
           cmake --build --preset develop
 
       - name: Execute unit tests NeoFOAM

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,5 @@
 name: Build NeoFOAM
-run-name: 'Build NeoFOAM
+run-name: 'Build NeoFOAM'
 
 on:
   push:
@@ -107,7 +107,7 @@ jobs:
             -DNEOFOAM_NEON_VERSION=${{ env.NEON_BRANCH }}
           cmake --build --preset develop
 
-      - name: Execute unit tests NeoN
+      - name: Execute unit tests NeoFOAM
         run: |
           source /usr/lib/openfoam/openfoam2406/etc/bashrc || true
           ctest --preset develop


### PR DESCRIPTION
Originally, the GitHub workflow of building NeoFOAM always pick the main branch of NeoN. 

This PR adds a branch selection mechanism to choose the correct NeoN's branch:
1. Check if NeoN's branch with the same name as the NeoFOAM's branch exists
2. If it exists, pick that branch
3. If not, pick NeoN's develop branch
