### PR TITLE
Avoid the potential unintended cancelations

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ env:
   OMPI_MCA_rmaps_base_oversubscribe: 1
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/trigger-lrz-gitlab-ci.yaml
+++ b/.github/workflows/trigger-lrz-gitlab-ci.yaml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:      # Optional: allows manual trigger
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
The current grouping for canceling concurrent CI pipelines may cause unintended cancelations.

For PRs, it works fine.
For pushes, it can cause unintended cancelations:
- A scheduled run at Sunday 8 am will cancel any ongoing push run to develop branch.
- A manual workflow_dispatch run will also cancel the scheduled run or push run.

This PR improves the grouping, which cleanly separates different events and avoid unintended cancelations of CI pipelines.