### PR TITLE
Skip IWYU and clang-tidy checks for PRs which do not need build

### DIFF
--- a/.github/workflows/static_checks.yaml
+++ b/.github/workflows/static_checks.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build-compilation-db:
+    if: "!contains(toJson(github.event.pull_request.labels.*.name), 'Skip-build')"
     name: Build with IWYU
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
There are 3 static checks in CI which always run for PRs:
- IWYU
- clang-tidy
- pre-commit

IWYU and clang-tidy are only used for source code. 
- IWYU ensures source files include all headers used in the C++ code. 
- clang-tidy checks C++ code for style violations, programming errors and best practices. 

In some cases, these two checks are not needed. e.g., changes in documentation. Basically, PRs which do not build source code do not need the two checks.

It can save time on waiting for CI checks to finish.