### PR TITLE
Make some static checks to be skipped on demand

### DIFF
--- a/.github/workflows/static_checks.yaml
+++ b/.github/workflows/static_checks.yaml
@@ -3,7 +3,11 @@ run-name: Static checks
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-compilation-db:


### PR DESCRIPTION
With the current CI setup, the static checks cannot be skipped when the `Skip-build` label is added after a PR is opened.

This PR makes the static checks to be skipped whenever the `Skip-build` is present.