### PR TITLE
Improve documentation and fix the link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 **[Requirements](#requirements)** |
 **[Compilation](#Compilation)** |
-**[Documentation](https://exasim-project.com/NeoFOAM/latest)** |
+**[Documentation](https://exasim-project.com/NeoFOAM/develop)** |
 # NeoFOAM
 
 NeoFOAM provides platform-portable implementations of common CFD algorithms and solvers using

--- a/README.md
+++ b/README.md
@@ -14,15 +14,17 @@ NeoFOAM has the following requirements
 *  _cmake 3.22+_
 *  _gcc >= 12_ or  _clang >= 18+_
 * OpenFOAM _2406_+
-* CUDA  _12.1_ (for GPU support)
+* NeoN (latest version)
 
 ## Compilation
 
 We provide several Cmake presets to set commmonly required flags for building NeoFOAM
 
-    cmake --list-presets # To list existing presets
-    cmake --preset production # Config for production
+    cmake --list-presets # List existing presets
+    cmake --preset production # Configure for production
     cmake --build --preset production # Build for production
+
+Check the documentation for [details](https://exasim-project.com/NeoFOAM/develop/gettingStarted.html#building-with-cmake-presets)
 
 ## Structure
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ We provide several Cmake presets to set commmonly required flags for building Ne
     cmake --preset production # Configure for production
     cmake --build --preset production # Build for production
 
-Check the documentation for [details](https://exasim-project.com/NeoFOAM/develop/gettingStarted.html#building-with-cmake-presets)
+Check the documentation for [details](https://exasim-project.com/NeoFOAM/develop/gettingStarted.html#getting-started)
 
 ## Structure
 

--- a/doc/gettingStarted.rst
+++ b/doc/gettingStarted.rst
@@ -1,118 +1,129 @@
-Getting started
+Getting Started
 ===============
 
-You can build NeoFOAM by following these steps:
+Follow these steps to build NeoFOAM:
 
 Clone the NeoFOAM repository:
 
-   .. code-block:: bash
+.. code-block:: bash
 
-      git clone https://github.com/exasim-project/NeoFOAM.git
+   git clone https://github.com/exasim-project/NeoFOAM.git
 
 Navigate to the NeoFOAM directory:
 
-   .. code-block:: bash
+.. code-block:: bash
 
-      cd NeoFOAM
+   cd NeoFOAM
 
-NeoFOAM uses CMake to build, thus the standard CMake procedure should work, however, we recommend using one of the provided CMake presets detailed below `below <Building with CMake Presets>`_. From a build directory, you can execute:
+NeoFOAM uses CMake for building. The standard CMake procedure works, but we recommend using one of the provided CMake presets (see :ref:`cmake-presets`). From a build directory, execute:
 
-   .. code-block:: bash
+.. code-block:: bash
 
-        mkdir build
-        cd build
-        cmake <DesiredBuildFlags> ..
-        cmake --build .
-        cmake --install .
+     mkdir build
+     cd build
+     cmake <DesiredBuildFlags> ..
+     cmake --build .
+     cmake --install .
 
-Build NeoFOAM against NeoN
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+Build NeoFOAM Against NeoN
+--------------------------
 
-There are three ways to build NeoFOAM against NeoN:
-1. Using the NeoN repo directory:
+There are three ways to link NeoFOAM with NeoN:
 
-   We can specify the path to the NeoN repo directory during the CMake configuration step:
+1. **Using the NeoN repository directory**
+
+   Specify the path to the NeoN repository during CMake configuration:
+
    .. code-block:: bash
 
       -DNEOFOAM_NEON_DIR=/path/to/NeoN/
 
-2. Using the NeoN submodule:
-   We can initialize and update the NeoN submodule in the NeoFOAM repo:
+2. **Using the NeoN submodule**
+
+   Initialize and update the NeoN submodule in the NeoFOAM repository:
+
    .. code-block:: bash
 
       git submodule update --init --recursive
 
-   Then, during the CMake configuration step, CMake will automatically detect and use the NeoN submodule.
+   During CMake configuration, the submodule will be automatically detected.
 
-3. Using automatically downloaded NeoN:
-   During the CMake configuration step, if neither of the above two options are provided, CMake will automatically download a pre-defined version of NeoN.
-   The pre-defined version is the main branch of NeoN by default, but it can be changed by specifying the desired version as follows:
+3. **Using automatically downloaded NeoN**
+
+   If neither of the above options is provided, CMake will download a predefined version of NeoN. By default, this is the `main` branch. To specify a different version:
+
    .. code-block:: bash
 
       -DNEOFOAM_NEON_VERSION=<desired_version>
 
-   The desired version can be a branch name, a tag name, or a commit hash.
+   `<desired_version>` can be a branch name, tag, or commit hash.
 
 Building for GPUs
-^^^^^^^^^^^^^^^^^^
+-----------------
 
-NeoFOAM supports GPUs from different vendors through NeoN, which uses Kokkos as the backend for performance portability.
-Check the NeoN documentation for [instructions](https://exasim-project.com/NeoN/latest/installation.html#building-for-gpus)
- on how to build for GPUs from different vendors.
+NeoFOAM supports GPUs from multiple vendors via NeoN, which uses Kokkos for performance portability.  
+For detailed instructions, see the `NeoN GPU installation guide <https://exasim-project.com/NeoN/latest/installation.html#building-for-gpus>`_.
 
 Building with CMake Presets
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------
 
-Additionally, we provide several CMake presets to set commonly required flags.
+.. _cmake-presets:
 
-   .. code-block:: bash
+Several CMake presets are provided to simplify building with common configurations:
 
-    cmake --list-presets # To list existing presets
+.. code-block:: bash
 
-To build NeoFOAM for production use, you can use the following commands:
+   cmake --list-presets  # List all available presets
 
-   .. code-block:: bash
+For production builds:
 
-    cmake --preset production # To configure with ninja and common kokkos flags
-    cmake --build --preset production # To compile with ninja and common kokkos flags
+.. code-block:: bash
 
-It should be noted that the build directory changes depending on the chosen preset. This way you can have different build directories for different presets and easily switch between them.
+   cmake --preset production       # Configure with Ninja and common Kokkos flags
+   cmake --build --preset production  # Compile with Ninja and common Kokkos flags
+
+Each preset uses its own build directory, allowing multiple configurations in parallel.
 
 Prerequisites
-^^^^^^^^^^^^^
+-------------
 
-The following tools are used in the development of this project:
+The following tools are required:
 
-The required tools for documentation:
-
-.. code-block:: bash
-
-    sudo apt install doxygen
-    pip install pre-commit sphinx furo breathe sphinx-sitemap
-
-
-The required tools for compilation (ubuntu latest 24.04):
+**Documentation tools:**
 
 .. code-block:: bash
 
-    sudo apt update
-    sudo apt install \
-    ninja-build \
-    clang-16 \
-    gcc-10 \
-    libomp-16-dev \
-    python3 \
-    python3-dev \
-    build-essential
+   sudo apt install doxygen
+   pip install pre-commit sphinx furo breathe sphinx-sitemap
 
-Run test case
-^^^^^^^^^^^^^
+**Compilation tools (Ubuntu 24.04):**
 
-To build these test cases, the CMake preset `profiling` should be used during config and build step for NeoFOAM.
+.. code-block:: bash
+
+   sudo apt update
+   sudo apt install \
+       ninja-build \
+       clang-16 \
+       gcc-10 \
+       libomp-16-dev \
+       python3 \
+       python3-dev \
+       build-essential
+
+Running Test Cases
+------------------
+
+To build test cases, use the `profiling` CMake preset:
 
 .. code-block:: bash
 
    cmake --preset profiling
    cmake --build --preset profiling
 
-Then go to the `tutorials` directory and use the predefined script `Allrun` in the directory of each test case to run the chosen test case.
+Then navigate to the `tutorials` directory and run the provided `Allrun` script in the directory of the chosen test case:
+
+.. code-block:: bash
+
+   cd tutorials/<test_case>
+   chmod +x Allrun  # Make sure it is executable
+   ./Allrun

--- a/doc/gettingStarted.rst
+++ b/doc/gettingStarted.rst
@@ -25,6 +25,13 @@ NeoFOAM uses CMake to build, thus the standard CMake procedure should work, howe
         cmake --build .
         cmake --install .
 
+Building for GPUs
+^^^^^^^^^^^^^^^^^^
+
+NeoFOAM supports GPUs from different vendors through NeoN, which uses Kokkos as the backend for performance portability.
+Check the NeoN documentation for [instructions](https://exasim-project.com/NeoN/latest/installation.html#building-for-gpus)
+ on how to build for GPUs from different vendors.
+
 Building with CMake Presets
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/gettingStarted.rst
+++ b/doc/gettingStarted.rst
@@ -61,7 +61,7 @@ There are three ways to link NeoFOAM with NeoN:
 Building for GPUs
 -----------------
 
-NeoFOAM supports GPUs from multiple vendors via NeoN, which uses Kokkos for performance portability.  
+NeoFOAM supports GPUs from multiple vendors via NeoN, which uses Kokkos for performance portability.
 For detailed instructions, see the `Building NeoN for GPUs <https://exasim-project.com/NeoN/latest/installation.html#building-for-gpus>`_.
 
 Building with CMake Presets

--- a/doc/gettingStarted.rst
+++ b/doc/gettingStarted.rst
@@ -61,15 +61,15 @@ There are three ways to link NeoFOAM with NeoN:
 Building for GPUs
 -----------------
 
-NeoFOAM supports GPUs from multiple vendors via NeoN, which uses Kokkos for performance portability.
-For detailed instructions, see the `NeoN GPU installation guide <https://exasim-project.com/NeoN/latest/installation.html#building-for-gpus>`_.
+NeoFOAM supports GPUs from multiple vendors via NeoN, which uses Kokkos for performance portability.  
+For detailed instructions, see the `Building NeoN for GPUs <https://exasim-project.com/NeoN/latest/installation.html#building-for-gpus>`_.
 
 Building with CMake Presets
 ---------------------------
 
 .. _cmake-presets:
 
-Several CMake presets are provided to simplify building with common configurations:
+Three CMake presets are provided to simplify building with common configurations:
 
 .. code-block:: bash
 
@@ -110,16 +110,10 @@ The following tools are required:
        python3-dev \
        build-essential
 
-Running Test Cases
+Running Tutorials
 ------------------
 
-To build test cases, use the `profiling` CMake preset:
-
-.. code-block:: bash
-
-   cmake --preset profiling
-   cmake --build --preset profiling
-
+Use any of NeoFOAM's CMake presets to configure and build NeoFOAM.
 Then navigate to the `tutorials` directory and run the provided `Allrun` script in the directory of the chosen test case:
 
 .. code-block:: bash

--- a/doc/gettingStarted.rst
+++ b/doc/gettingStarted.rst
@@ -3,11 +3,11 @@ Getting started
 
 You can build NeoFOAM by following these steps:
 
-Clone the NeoFOAM repository including NeoFOAM integrated as a submodule:
+Clone the NeoFOAM repository:
 
    .. code-block:: bash
 
-      git clone --recurse-submodules https://github.com/exasim-project/NeoFOAM.git
+      git clone https://github.com/exasim-project/NeoFOAM.git
 
 Navigate to the NeoFOAM directory:
 
@@ -24,6 +24,34 @@ NeoFOAM uses CMake to build, thus the standard CMake procedure should work, howe
         cmake <DesiredBuildFlags> ..
         cmake --build .
         cmake --install .
+
+Build NeoFOAM against NeoN
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+There are three ways to build NeoFOAM against NeoN:
+1. Using the NeoN repo directory:
+
+   We can specify the path to the NeoN repo directory during the CMake configuration step:
+   .. code-block:: bash
+
+      -DNEOFOAM_NEON_DIR=/path/to/NeoN/
+
+2. Using the NeoN submodule:
+   We can initialize and update the NeoN submodule in the NeoFOAM repo:
+   .. code-block:: bash
+
+      git submodule update --init --recursive
+
+   Then, during the CMake configuration step, CMake will automatically detect and use the NeoN submodule.
+
+3. Using automatically downloaded NeoN:
+   During the CMake configuration step, if neither of the above two options are provided, CMake will automatically download a pre-defined version of NeoN.
+   The pre-defined version is the main branch of NeoN by default, but it can be changed by specifying the desired version as follows:
+   .. code-block:: bash
+
+      -DNEOFOAM_NEON_VERSION=<desired_version>
+
+   The desired version can be a branch name, a tag name, or a commit hash.
 
 Building for GPUs
 ^^^^^^^^^^^^^^^^^^

--- a/doc/gettingStarted.rst
+++ b/doc/gettingStarted.rst
@@ -61,7 +61,7 @@ There are three ways to link NeoFOAM with NeoN:
 Building for GPUs
 -----------------
 
-NeoFOAM supports GPUs from multiple vendors via NeoN, which uses Kokkos for performance portability.  
+NeoFOAM supports GPUs from multiple vendors via NeoN, which uses Kokkos for performance portability.
 For detailed instructions, see the `NeoN GPU installation guide <https://exasim-project.com/NeoN/latest/installation.html#building-for-gpus>`_.
 
 Building with CMake Presets


### PR DESCRIPTION
Improve documentation 
- Make it easier for users to find relevant info 
- Add a section of building NeoFOAM for GPUs and provide a link to the instructions 
- Add a section of building NeoFOAM against NeoN

Fix the link to the NeoFOAM documentation in the repo's README.

Note:
The link to the repo's documentation should automatically point to the correct version according to the branch. 
It will be done in a separate PR.
