### PR TITLE
Automatically update link to documentation in README

### DIFF
--- a/.github/workflows/build_doc.yaml
+++ b/.github/workflows/build_doc.yaml
@@ -52,14 +52,14 @@ jobs:
         target-folder: ${{ github.ref_name }}
 
     # 3. DEPLOY FOR MAIN (stable)
-    - name: Deploy Latest (main)
+    - name: Deploy Main
       if: >
         github.event.pull_request.merged &&
         github.event.pull_request.base.ref == 'main'
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         folder: docs_build
-        target-folder: latest
+        target-folder: main
 
     # 4. DEPLOY FOR DEVELOP (dev preview)
     - name: Deploy Develop

--- a/.github/workflows/update-readme-doc-link.yaml
+++ b/.github/workflows/update-readme-doc-link.yaml
@@ -1,0 +1,22 @@
+name: update README documentation link after merge
+
+on:
+  pull_request:
+    types: closed
+
+jobs:
+  fix-readme:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Rewrite develop link to main
+        run: |
+          sed -i 's|https://exasim-project.com/NeoFOAM/develop|https://exasim-project.com/NeoFOAM/main|g' README.md docs/**/*.md || true
+
+      - name: Commit and push changes
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.MERGE_TOKEN }}
+          commit_message: "update documentation link for main"


### PR DESCRIPTION
Since the documentation for main and develop branches are located in different target folder, 
we need a way to update the link to the documentation according to the branch being selected.

This PR brings:
- a new GitHub workflow which updates the link to documentation after the develop branch is merged to the main branch
- change the target folder of documentation for main branch to `main` instead of `latest`

Using `latest` for documentation of main branch is confusing because develop branch is currently the active development branch, which is actually the latest one. Using the branch name for the target folder of documentation should make it clear about which branch the documentation refers to.