### PR TITLE
Pass NeoN branch explicitly for building NeoFOAM in LRZ GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -111,7 +111,7 @@ benchmark-triggered-from-FA-nvidia:
     - .openfoam-env-setup
     - .trigger-from-neofoam-for-benchmarking
   script:
-    - ./ci/lrz-gitlab/build-and-test.sh nvidia main profiling
+    - ./ci/lrz-gitlab/build-and-test.sh nvidia $NEON_BRANCH profiling
     - ./benchmarks/benchmarkSuite/cleanAll.sh
     - ./benchmarks/benchmarkSuite/runAll.sh
     # Check for produced results
@@ -124,7 +124,7 @@ benchmark-triggered-from-FA-amd:
     - .trigger-from-neofoam-for-benchmarking
   script:
     - export PATH=$PATH:$PWD/build/profiling/bin/benchmarks
-    - ./ci/lrz-gitlab/build-and-test.sh amd main profiling
+    - ./ci/lrz-gitlab/build-and-test.sh amd $NEON_BRANCH profiling
     - ./benchmarks/benchmarkSuite/cleanAll.sh
     - ./benchmarks/benchmarkSuite/runAll.sh
     # Check for produced results

--- a/ci/lrz-gitlab/build-and-test.sh
+++ b/ci/lrz-gitlab/build-and-test.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 # Argument parsing
 GPU_VENDOR=${1:?Error: GPU vendor (nvidia|amd) must be specified}
-NEON_BRANCH=${2:-main} # Default to 'main' if not provided
+NEON_BRANCH=${2:?Error: NeoN branch must be specified}
 PRESET=${3:-develop}   # Which CMakePreset to use, defaults to 'develop'
 
 echo "=== GPU vendor=$GPU_VENDOR, NeoN branch=$NEON_BRANCH ==="


### PR DESCRIPTION
The default NeoN's branch to use for building NeoFOAM in LRZ GitLab CI is `main` branch if not specified otherwise.
However, which NeoN's branch to use is already decided on GitHub CI and the name of NeoN's branch is always passed as an argument when triggering LRZ GitLab CI pipelines.

The NeoN's branch to use in LRZ GitLab CI should be always specified explicitly instead of using a fallback.

Closes #179 
