### PR TITLE
Adding scorep build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,45 @@
 
 cmake_minimum_required(VERSION 3.22.0)
 
+if(ENABLE_PROFILING)
+    project(Bootstrap)
+    # Always prepend (possible) Score-P bootstrap location
+    set(SCOREP_PREFIX "${CMAKE_BINARY_DIR}/scorep")
+    set(SCOREP_BIN    "${SCOREP_PREFIX}/bin")
+    set(ENV{PATH} "${SCOREP_BIN}:$ENV{PATH}")
+
+    # Try to locate Score-P
+    find_program(SCOREP_INFO scorep-info HINTS ${SCOREP_BIN})
+
+    if(NOT SCOREP_INFO)
+        message(STATUS "[Score-P] Not found. Bootstrapping…")
+
+        include(cmake/scorep.cmake)
+
+        message(STATUS "[Score-P] Now run:  cmake --build .   then rerun configuration with:  cmake ..")
+        return()  # stop configure 
+    else()
+        message(STATUS "[Score-P] Found: ${SCOREP_INFO}")
+    endif()
+
+    # Score-P exists → select wrappers according to compiler family
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        set(CMAKE_C_COMPILER   "${SCOREP_BIN}/scorep-gcc"  CACHE STRING "" FORCE)
+        set(CMAKE_CXX_COMPILER "${SCOREP_BIN}/scorep-g++"  CACHE STRING "" FORCE)
+	set(ENV{SCOREP_WRAPPER_INSTRUMENTER_FLAGS}
+            "--thread=pthread --mpp=none --kokkos --cuda"
+         )
+    elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        set(CMAKE_C_COMPILER   "${SCOREP_BIN}/scorep-clang"   CACHE STRING "" FORCE)
+        set(CMAKE_CXX_COMPILER "${SCOREP_BIN}/scorep-clang++" CACHE STRING "" FORCE)
+	set(ENV{SCOREP_WRAPPER_INSTRUMENTER_FLAGS}
+            "--thread=pthread --mpp=none --kokkos"
+        )
+    else()
+        message(FATAL_ERROR "Unsupported compiler family for Score-P")
+    endif()
+endif()
+
 project(
   NeoFOAM
   LANGUAGES C CXX
@@ -49,23 +88,11 @@ endif()
 
 include(cmake/CxxThirdParty.cmake)
 
-if(ENABLE_PROFILING)
-    add_dependencies(NeoN scorep_build)
-endif()
-
 add_subdirectory(include)
 add_subdirectory(src)
 
-if(ENABLE_PROFILING)
-    add_dependencies(NeoFOAM scorep_build)
-endif()
-
 if(NEOFOAM_BUILD_EXAMPLES)
   add_subdirectory(examples)
-endif()
-
-if(ENABLE_PROFILING)
-    add_dependencies(neoIcoFoam scorep_build)
 endif()
 
 if(NEOFOAM_BUILD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ endif()
 option(NEOFOAM_BUILD_EXAMPLES "Build the NeoN examples" ON)
 option(NEOFOAM_BUILD_TESTS "Build the unit tests" OFF)
 option(NEOFOAM_BUILD_BENCHMARKS "Build benchmarks" OFF)
+option(ENABLE_PROFILING "Build Score-P to enable profiling" OFF)
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 20)
@@ -48,11 +49,23 @@ endif()
 
 include(cmake/CxxThirdParty.cmake)
 
+if(ENABLE_PROFILING)
+    add_dependencies(NeoN scorep_build)
+endif()
+
 add_subdirectory(include)
 add_subdirectory(src)
 
+if(ENABLE_PROFILING)
+    add_dependencies(NeoFOAM scorep_build)
+endif()
+
 if(NEOFOAM_BUILD_EXAMPLES)
   add_subdirectory(examples)
+endif()
+
+if(ENABLE_PROFILING)
+    add_dependencies(neoIcoFoam scorep_build)
 endif()
 
 if(NEOFOAM_BUILD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,18 +3,6 @@
 
 cmake_minimum_required(VERSION 3.22.0)
 
-if(NEOFOAM_WITH_SCOREP)
-    include(cmake/scorep.cmake)
-    scorep_check(SCOREP_FOUND)
-    if(NOT SCOREP_FOUND)
-	include(cmake/CxxThirdParty.cmake)
-	project(bootstrap_scorep LANGUAGES NONE)
-        scorep_add_external_project()
-        return()   # required to stop the configure after scorep on first cmake call
-    endif()
-    scorep_setup_compilers()
-endif()
-
 project(
   NeoFOAM
   LANGUAGES C CXX
@@ -43,6 +31,16 @@ set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 # Set the output directories for all binaries and libraries
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+
+if(NEOFOAM_WITH_SCOREP)
+    include(cmake/scorep.cmake)
+    scorep_check(SCOREP_FOUND)
+    if(NOT SCOREP_FOUND)
+        include(cmake/CxxThirdParty.cmake)
+        scorep_add_external_project()
+        return()   # required to stop the configure after scorep on first cmake call
+    endif()
+endif()
 
 include(cmake/OpenFOAM.cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,43 +3,16 @@
 
 cmake_minimum_required(VERSION 3.22.0)
 
-if(ENABLE_PROFILING)
-    project(Bootstrap)
-    # Always prepend (possible) Score-P bootstrap location
-    set(SCOREP_PREFIX "${CMAKE_BINARY_DIR}/scorep")
-    set(SCOREP_BIN    "${SCOREP_PREFIX}/bin")
-    set(ENV{PATH} "${SCOREP_BIN}:$ENV{PATH}")
-
-    # Try to locate Score-P
-    find_program(SCOREP_INFO scorep-info HINTS ${SCOREP_BIN})
-
-    if(NOT SCOREP_INFO)
-        message(STATUS "[Score-P] Not found. Bootstrapping…")
-
-        include(cmake/scorep.cmake)
-
-        message(STATUS "[Score-P] Now run:  cmake --build .   then rerun configuration with:  cmake ..")
-        return()  # stop configure 
-    else()
-        message(STATUS "[Score-P] Found: ${SCOREP_INFO}")
+if(NEOFOAM_WITH_SCOREP)
+    include(cmake/scorep.cmake)
+    scorep_check(SCOREP_FOUND)
+    if(NOT SCOREP_FOUND)
+	include(cmake/CxxThirdParty.cmake)
+	project(bootstrap_scorep LANGUAGES NONE)
+        scorep_add_external_project()
+        return()   # required to stop the configure after scorep on first cmake call
     endif()
-
-    # Score-P exists → select wrappers according to compiler family
-    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        set(CMAKE_C_COMPILER   "${SCOREP_BIN}/scorep-gcc"  CACHE STRING "" FORCE)
-        set(CMAKE_CXX_COMPILER "${SCOREP_BIN}/scorep-g++"  CACHE STRING "" FORCE)
-	set(ENV{SCOREP_WRAPPER_INSTRUMENTER_FLAGS}
-            "--thread=pthread --mpp=none --kokkos --cuda"
-         )
-    elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        set(CMAKE_C_COMPILER   "${SCOREP_BIN}/scorep-clang"   CACHE STRING "" FORCE)
-        set(CMAKE_CXX_COMPILER "${SCOREP_BIN}/scorep-clang++" CACHE STRING "" FORCE)
-	set(ENV{SCOREP_WRAPPER_INSTRUMENTER_FLAGS}
-            "--thread=pthread --mpp=none --kokkos"
-        )
-    else()
-        message(FATAL_ERROR "Unsupported compiler family for Score-P")
-    endif()
+    scorep_setup_compilers()
 endif()
 
 project(
@@ -58,7 +31,7 @@ endif()
 option(NEOFOAM_BUILD_EXAMPLES "Build the NeoN examples" ON)
 option(NEOFOAM_BUILD_TESTS "Build the unit tests" OFF)
 option(NEOFOAM_BUILD_BENCHMARKS "Build benchmarks" OFF)
-option(ENABLE_PROFILING "Build Score-P to enable profiling" OFF)
+option(NEOFOAM_WITH_SCOREP "Build with Score-P support " OFF)
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 20)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -64,6 +64,22 @@
         "NEOFOAM_BUILD_EXAMPLES": "ON",
         "CMAKE_CXX_FLAGS": "-fno-omit-frame-pointer $env{CXXFLAGS}"
       }
+    },
+    {
+      "name": "scorep",
+      "inherits": ["production"],
+      "displayName": "Score-P Profiling",
+      "description": "Build with Score-P instrumentation",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_CXX_FLAGS": "-fno-omit-frame-pointer",
+        "ENABLE_PROFILING": "ON"
+      },
+      "environment": {
+        "SCOREP_WRAPPER_INSTRUMENTER_FLAGS": "--thread=pthread --mpp=none --kokkos --cuda",
+        "NVCC_WRAPPER_DEFAULT_COMPILER": "scorep-g++",
+	"CMAKE_CXX_COMPILER": "${sourceDir}/cmake/bin/neofoam-cxx-wrapper"
+      }
     }
   ],
   "buildPresets": [
@@ -87,6 +103,13 @@
       "description": "Build for profiling use",
       "configurePreset": "profiling",
       "configuration": "RelWithDebInfo"
+    },
+    {
+      "name": "scorep",
+      "displayName": "Score-P Profiling",
+      "description": "Build for profiling use",
+      "configurePreset": "scorep",
+      "configuration": "Release"
     }
   ],
   "testPresets": [

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 5,
   "cmakeMinimumRequired": {
     "major": 3,
     "minor": 22,
@@ -66,7 +66,7 @@
       }
     },
     {
-      "name": "scorep",
+      "name": "instrumented",
       "inherits": ["production"],
       "displayName": "Score-P Profiling",
       "description": "Build with Score-P instrumentation",
@@ -74,6 +74,11 @@
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_CXX_FLAGS": "-fno-omit-frame-pointer",
         "NEOFOAM_WITH_SCOREP": "ON"
+      },
+      "environment": {
+	"PATH": "${sourceDir}/build/scorep/bin:$penv{PATH}",
+        "NVCC_WRAPPER_DEFAULT_COMPILER": "scorep-g++",
+	"SCOREP_WRAPPER_INSTRUMENTER_FLAGS": "--thread=pthread --mpp=none --kokkos"
       }
     }
   ],
@@ -100,10 +105,10 @@
       "configuration": "RelWithDebInfo"
     },
     {
-      "name": "scorep",
+      "name": "instrumented",
       "displayName": "Score-P Profiling",
       "description": "Build for profiling use",
-      "configurePreset": "scorep",
+      "configurePreset": "instrumented",
       "configuration": "Release"
     }
   ],

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -73,7 +73,7 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_CXX_FLAGS": "-fno-omit-frame-pointer",
-        "ENABLE_PROFILING": "ON"
+        "NEOFOAM_WITH_SCOREP": "ON"
       }
     }
   ],

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -74,11 +74,6 @@
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_CXX_FLAGS": "-fno-omit-frame-pointer",
         "ENABLE_PROFILING": "ON"
-      },
-      "environment": {
-        "SCOREP_WRAPPER_INSTRUMENTER_FLAGS": "--thread=pthread --mpp=none --kokkos --cuda",
-        "NVCC_WRAPPER_DEFAULT_COMPILER": "scorep-g++",
-	"CMAKE_CXX_COMPILER": "${sourceDir}/cmake/bin/neofoam-cxx-wrapper"
       }
     }
   ],

--- a/cmake/CxxThirdParty.cmake
+++ b/cmake/CxxThirdParty.cmake
@@ -7,35 +7,6 @@ if(NeoFOAM_BUILD_TESTS OR NeoFOAM_BUILD_BENCHMARKS)
   cpmaddpackage(NAME Catch2 GITHUB_REPOSITORY catchorg/Catch2 VERSION 3.4.0)
 endif()
 
-if(ENABLE_PROFILING)
-cpmaddpackage(
-    NAME ScoreP
-    URL https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-9.3/scorep-9.3.tar.gz
-    URL_HASH SHA256=5498b31b1d6c04b08a9d408320a7515e884538d248de58b6dd11b48c8f364112
-    DOWNLOAD_ONLY YES
-  )
-  cpmaddpackage(
-    NAME binutils
-    URL https://ftp.gnu.org/gnu/binutils/binutils-2.43.tar.gz
-    URL_HASH SHA256=025c436d15049076ebe511d29651cc4785ee502965a8839936a65518582bdd64
-    DOWNLOAD_ONLY YES
-  )
-  include(ExternalProject)
-  ExternalProject_Add(scorep_build
-    SOURCE_DIR ${ScoreP_SOURCE_DIR}
-    CONFIGURE_COMMAND ${ScoreP_SOURCE_DIR}/configure
-        --prefix=${CMAKE_BINARY_DIR}/scorep
-        --with-libgotcha=download
-        --with-libbfd=download
-        --with-cuda
-    BUILD_COMMAND make -j
-    INSTALL_COMMAND make install
-  )
-  ExternalProject_Get_Property(scorep_build INSTALL_DIR)
-  set(SCOREP_ROOT ${INSTALL_DIR})
-  set(ENV{SCOREP_ROOT} ${INSTALL_DIR})
-endif()
-
 if(NEOFOAM_NEON_VIA_CPM)
   if(NOT DEFINED NEOFOAM_NEON_VERSION)
     set(NEOFOAM_NEON_VERSION
@@ -55,4 +26,3 @@ if(NEOFOAM_NEON_VIA_CPM)
     "Kokkos_ENABLE_CUDA ${Kokkos_ENABLE_CUDA}"
     "Kokkos_ENABLE_HIP ${Kokkos_ENABLE_HIP}")
 endif()
-

--- a/cmake/CxxThirdParty.cmake
+++ b/cmake/CxxThirdParty.cmake
@@ -15,8 +15,6 @@ function(scorep_add_external_project)
                               Defaults to 'gcc', if this is not the intended 
 			      compiler set manually via SCOREP_COMPILER_SUITE")
 
-    set(SCOREP_PREFIX "${CMAKE_BINARY_DIR}/scorep")
-
     ExternalProject_Add(scorep_build
         SOURCE_DIR     ${CMAKE_BINARY_DIR}/_deps/scorep-src
         URL            https://zenodo.org/records/17297069/files/scorep-9.3.tar.gz

--- a/cmake/CxxThirdParty.cmake
+++ b/cmake/CxxThirdParty.cmake
@@ -7,6 +7,35 @@ if(NeoFOAM_BUILD_TESTS OR NeoFOAM_BUILD_BENCHMARKS)
   cpmaddpackage(NAME Catch2 GITHUB_REPOSITORY catchorg/Catch2 VERSION 3.4.0)
 endif()
 
+if(ENABLE_PROFILING)
+cpmaddpackage(
+    NAME ScoreP
+    URL https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-9.3/scorep-9.3.tar.gz
+    URL_HASH SHA256=5498b31b1d6c04b08a9d408320a7515e884538d248de58b6dd11b48c8f364112
+    DOWNLOAD_ONLY YES
+  )
+  cpmaddpackage(
+    NAME binutils
+    URL https://ftp.gnu.org/gnu/binutils/binutils-2.43.tar.gz
+    URL_HASH SHA256=025c436d15049076ebe511d29651cc4785ee502965a8839936a65518582bdd64
+    DOWNLOAD_ONLY YES
+  )
+  include(ExternalProject)
+  ExternalProject_Add(scorep_build
+    SOURCE_DIR ${ScoreP_SOURCE_DIR}
+    CONFIGURE_COMMAND ${ScoreP_SOURCE_DIR}/configure
+        --prefix=${CMAKE_BINARY_DIR}/scorep
+        --with-libgotcha=download
+        --with-libbfd=download
+        --with-cuda
+    BUILD_COMMAND make -j
+    INSTALL_COMMAND make install
+  )
+  ExternalProject_Get_Property(scorep_build INSTALL_DIR)
+  set(SCOREP_ROOT ${INSTALL_DIR})
+  set(ENV{SCOREP_ROOT} ${INSTALL_DIR})
+endif()
+
 if(NEOFOAM_NEON_VIA_CPM)
   if(NOT DEFINED NEOFOAM_NEON_VERSION)
     set(NEOFOAM_NEON_VERSION
@@ -26,3 +55,4 @@ if(NEOFOAM_NEON_VIA_CPM)
     "Kokkos_ENABLE_CUDA ${Kokkos_ENABLE_CUDA}"
     "Kokkos_ENABLE_HIP ${Kokkos_ENABLE_HIP}")
 endif()
+

--- a/cmake/CxxThirdParty.cmake
+++ b/cmake/CxxThirdParty.cmake
@@ -2,6 +2,44 @@
 # SPDX-FileCopyrightText: 2023 NeoFOAM authors
 
 include(cmake/CPM.cmake)
+include(ExternalProject)
+
+function(scorep_add_external_project)
+    message(STATUS "[Score-P] Bootstrapping Score-P via ExternalProject_Add")
+
+    # currently defaults to gcc need to be set to clang manually by the user
+    set(SCOREP_COMPILER_SUITE "gcc" CACHE STRING "Score-P compiler suite (gcc, clang, intel, ...)")
+    set_property(CACHE SCOREP_COMPILER_SUITE PROPERTY STRINGS gcc clang)
+
+    message(STATUS "[Score-P] Compiler suite: ${SCOREP_COMPILER_SUITE}
+                              Defaults to 'gcc', if this is not the intended 
+			      compiler set manually via SCOREP_COMPILER_SUITE")
+
+    set(SCOREP_PREFIX "${CMAKE_BINARY_DIR}/scorep")
+
+    ExternalProject_Add(scorep_build
+        SOURCE_DIR     ${CMAKE_BINARY_DIR}/_deps/scorep-src
+        URL            https://zenodo.org/records/17297069/files/scorep-9.3.tar.gz
+	URL_HASH       MD5=661e52f439614e51164526d5a2c28b7a
+        DOWNLOAD_NO_PROGRESS ON
+	DOWNLOAD_EXTRACT_TIMESTAMP OFF
+        CONFIGURE_COMMAND
+            env CC=${CMAKE_C_COMPILER}
+                CXX=${CMAKE_CXX_COMPILER}
+            ${CMAKE_BINARY_DIR}/_deps/scorep-src/configure
+                --prefix=${SCOREP_PREFIX}
+                --with-libgotcha=download
+                --with-libbfd=download
+		--disable-cuda
+                --with-nocross-compiler-suite=${SCOREP_COMPILER_SUITE}
+
+        BUILD_COMMAND   make -j
+        INSTALL_COMMAND make install
+    )
+
+    message(STATUS "[Score-P] Bootstrap scheduled → run: cmake --build --preset scorep 
+            && and then reconfigure and build again")
+endfunction()
 
 if(NeoFOAM_BUILD_TESTS OR NeoFOAM_BUILD_BENCHMARKS)
   cpmaddpackage(NAME Catch2 GITHUB_REPOSITORY catchorg/Catch2 VERSION 3.4.0)

--- a/cmake/scorep.cmake
+++ b/cmake/scorep.cmake
@@ -1,7 +1,7 @@
 # Check whether scorep is present and set flag
 function(scorep_check OUTVAR)
     # Paths based on expected bootstrap location
-    set(SCOREP_PREFIX "${CMAKE_BINARY_DIR}/scorep")
+    set(SCOREP_PREFIX "${PROJECT_SOURCE_DIR}/build/scorep" CACHE STRING "Installation prefix for Score-P")
     set(SCOREP_BIN    "${SCOREP_PREFIX}/bin")
 
     # Prepend potential Score-P install to PATH
@@ -17,27 +17,3 @@ function(scorep_check OUTVAR)
         set(${OUTVAR} FALSE PARENT_SCOPE)
     endif()
 endfunction()
-
-
-# Setup compiler wrappers AFTER Score-P is present
-function(scorep_setup_compilers)
-    set(SCOREP_PREFIX "${CMAKE_BINARY_DIR}/scorep")
-    set(SCOREP_BIN    "${SCOREP_PREFIX}/bin")
-
-    if(SCOREP_COMPILER_SUITE STREQUAL "gcc")
-        message(STATUS "[Score-P] Using GNU Score-P wrappers")
-        set(CMAKE_C_COMPILER   "${SCOREP_BIN}/scorep-gcc"  CACHE STRING "" FORCE)
-        set(CMAKE_CXX_COMPILER "${SCOREP_BIN}/scorep-g++"  CACHE STRING "" FORCE)
-    elseif(SCOREP_COMPILER_SUITE STREQUAL "clang")
-        message(STATUS "[Score-P] Using Clang Score-P wrappers")
-        set(CMAKE_C_COMPILER   "${SCOREP_BIN}/scorep-clang"   CACHE STRING "" FORCE)
-        set(CMAKE_CXX_COMPILER "${SCOREP_BIN}/scorep-clang++" CACHE STRING "" FORCE)
-    else()
-        message(FATAL_ERROR "[Score-P] Unsupported compiler family: ${CMAKE_CXX_COMPILER_ID}")
-    endif()
-
-    set(ENV{SCOREP_WRAPPER_INSTRUMENTER_FLAGS} "--thread=pthread --mpp=none --kokkos")
-
-    message(STATUS "[Score-P] Wrapper flags: $ENV{SCOREP_WRAPPER_INSTRUMENTER_FLAGS}")
-endfunction()
-

--- a/cmake/scorep.cmake
+++ b/cmake/scorep.cmake
@@ -1,36 +1,43 @@
-# ================================================================
-#   ScorePBootstrap.cmake
-#   Bootstraps Score-P if not yet present, then stops configuration
-# ================================================================
+# Check whether scorep is present and set flag
+function(scorep_check OUTVAR)
+    # Paths based on expected bootstrap location
+    set(SCOREP_PREFIX "${CMAKE_BINARY_DIR}/scorep")
+    set(SCOREP_BIN    "${SCOREP_PREFIX}/bin")
 
-include(ExternalProject)
+    # Prepend potential Score-P install to PATH
+    set(ENV{PATH} "${SCOREP_BIN}:$ENV{PATH}")
 
-# Detect compiler family for Score-P
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set(SCOREP_COMPILER_SUITE gcc)
-elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(SCOREP_COMPILER_SUITE clang)
-else()
-    message(FATAL_ERROR "[Score-P] Unsupported compiler: ${CMAKE_CXX_COMPILER_ID}")
-endif()
-message(STATUS "[Score-P] Compiler: ${SCOREP_COMPILER_SUITE}")
+    find_program(SCOREP_INFO scorep-info HINTS ${SCOREP_BIN})
 
-ExternalProject_Add(scorep_build
-    SOURCE_DIR     ${CMAKE_BINARY_DIR}/_deps/scorep-src
-    URL            https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-9.3/scorep-9.3.tar.gz
-    URL_HASH       SHA256=5498b31b1d6c04b08a9d408320a7515e884538d248de58b6dd11b48c8f364112
+    if(SCOREP_INFO)
+        message(STATUS "[Score-P] Found: ${SCOREP_INFO}")
+        set(${OUTVAR} TRUE PARENT_SCOPE)
+    else()
+        message(STATUS "[Score-P] Not found → will bootstrap")
+        set(${OUTVAR} FALSE PARENT_SCOPE)
+    endif()
+endfunction()
 
-    CONFIGURE_COMMAND
-        env CC=${CMAKE_C_COMPILER}
-            CXX=${CMAKE_CXX_COMPILER} 
-        ${CMAKE_BINARY_DIR}/_deps/scorep-src/configure
-            --prefix=${SCOREP_PREFIX}
-            --with-libgotcha=download
-            --with-libbfd=download
-            --with-cuda
-	    --with-nocross-compiler-suite=${SCOREP_COMPILER_SUITE}
 
-    BUILD_COMMAND   make -j
-    INSTALL_COMMAND make install
-)
+# Setup compiler wrappers AFTER Score-P is present
+function(scorep_setup_compilers)
+    set(SCOREP_PREFIX "${CMAKE_BINARY_DIR}/scorep")
+    set(SCOREP_BIN    "${SCOREP_PREFIX}/bin")
+
+    if(SCOREP_COMPILER_SUITE STREQUAL "gcc")
+        message(STATUS "[Score-P] Using GNU Score-P wrappers")
+        set(CMAKE_C_COMPILER   "${SCOREP_BIN}/scorep-gcc"  CACHE STRING "" FORCE)
+        set(CMAKE_CXX_COMPILER "${SCOREP_BIN}/scorep-g++"  CACHE STRING "" FORCE)
+    elseif(SCOREP_COMPILER_SUITE STREQUAL "clang")
+        message(STATUS "[Score-P] Using Clang Score-P wrappers")
+        set(CMAKE_C_COMPILER   "${SCOREP_BIN}/scorep-clang"   CACHE STRING "" FORCE)
+        set(CMAKE_CXX_COMPILER "${SCOREP_BIN}/scorep-clang++" CACHE STRING "" FORCE)
+    else()
+        message(FATAL_ERROR "[Score-P] Unsupported compiler family: ${CMAKE_CXX_COMPILER_ID}")
+    endif()
+
+    set(ENV{SCOREP_WRAPPER_INSTRUMENTER_FLAGS} "--thread=pthread --mpp=none --kokkos")
+
+    message(STATUS "[Score-P] Wrapper flags: $ENV{SCOREP_WRAPPER_INSTRUMENTER_FLAGS}")
+endfunction()
 

--- a/cmake/scorep.cmake
+++ b/cmake/scorep.cmake
@@ -1,0 +1,36 @@
+# ================================================================
+#   ScorePBootstrap.cmake
+#   Bootstraps Score-P if not yet present, then stops configuration
+# ================================================================
+
+include(ExternalProject)
+
+# Detect compiler family for Score-P
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(SCOREP_COMPILER_SUITE gcc)
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(SCOREP_COMPILER_SUITE clang)
+else()
+    message(FATAL_ERROR "[Score-P] Unsupported compiler: ${CMAKE_CXX_COMPILER_ID}")
+endif()
+message(STATUS "[Score-P] Compiler: ${SCOREP_COMPILER_SUITE}")
+
+ExternalProject_Add(scorep_build
+    SOURCE_DIR     ${CMAKE_BINARY_DIR}/_deps/scorep-src
+    URL            https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-9.3/scorep-9.3.tar.gz
+    URL_HASH       SHA256=5498b31b1d6c04b08a9d408320a7515e884538d248de58b6dd11b48c8f364112
+
+    CONFIGURE_COMMAND
+        env CC=${CMAKE_C_COMPILER}
+            CXX=${CMAKE_CXX_COMPILER} 
+        ${CMAKE_BINARY_DIR}/_deps/scorep-src/configure
+            --prefix=${SCOREP_PREFIX}
+            --with-libgotcha=download
+            --with-libbfd=download
+            --with-cuda
+	    --with-nocross-compiler-suite=${SCOREP_COMPILER_SUITE}
+
+    BUILD_COMMAND   make -j
+    INSTALL_COMMAND make install
+)
+


### PR DESCRIPTION
Added scorep profling preset with option to automatically build scorep via cmake.
Since the compiler wrapper scorep-g++ or it's clang variant are required for the configure of NeoFOAM, this needs to happen in a two step process. 

1. on first call of `cmake --preset instrumented`, look for scorep existance, if not found exit the configuration after external project at
2. Run `cmake --build --preset instrumented` to compile scorep
3. Run `cmake --preset instrumented` again and this time the new scorep is found and NeoFOAM configures normally
4. Run `cmake --build --preset instrumented` to compile NeoFOAM and dependencies

**Status update:**
- Reduce code in the main cmake
- scorep is compiled with --no-cuda, as this crashed the profiling in all cases due to asynchronos memcopy.
- the preset is now called "instrumented" since scorep is installed into build/scorep, this enables to recompile NeoFOAM multiple times without reinstalling scorep
- profiling only works with scorep is injected via NVCC_WRAPPER_DEFAULT_COMPILER
- when running the instrumented neoIcoFoam, a directory `scorep-<timestap>` should appear that can be visualised in cube
- One might need to set SCOREP_ENABLE_PROFILING=1 and SCOREP_ENABLE_TRACING=0 when running the executable