### PR TITLE
Cover benchmark code in default CI pipelines

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -95,7 +95,8 @@ jobs:
             -DNeoN_DEVEL_TOOLS=OFF \
             -DNeoN_BUILD_TESTS=OFF \
             -DNeoN_ENABLE_MPI_WITH_THREAD_SUPPORT=OFF \
-            -DNEOFOAM_NEON_VERSION=${{ env.NEON_BRANCH }}
+            -DNEOFOAM_NEON_VERSION=${{ env.NEON_BRANCH }} \
+            -DNEOFOAM_BUILD_BENCHMARKS=ON
           cmake --build --preset develop
 
       - name: Execute unit tests of NeoFOAM

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -102,4 +102,4 @@ jobs:
       - name: Execute unit tests of NeoFOAM
         run: |
           source /usr/lib/openfoam/openfoam2406/etc/bashrc || true
-          ctest --preset $PRESET -E bench --output-on-failure
+          ctest --preset develop -E bench --output-on-failure

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -103,4 +103,3 @@ jobs:
         run: |
           source /usr/lib/openfoam/openfoam2406/etc/bashrc || true
           ctest --preset $PRESET -E bench --output-on-failure
-

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -102,4 +102,5 @@ jobs:
       - name: Execute unit tests of NeoFOAM
         run: |
           source /usr/lib/openfoam/openfoam2406/etc/bashrc || true
-          ctest --preset develop
+          ctest --preset $PRESET -E bench --output-on-failure
+

--- a/ci/lrz-gitlab/build-and-test.sh
+++ b/ci/lrz-gitlab/build-and-test.sh
@@ -55,7 +55,7 @@ if [[ "$GPU_VENDOR" == "nvidia" ]]; then
         -DNEOFOAM_NEON_DIR=../NeoN \
         -DCMAKE_CUDA_ARCHITECTURES=90 \
         -DNeoN_WITH_THREADS=OFF \
-        -DNeoFOAM_BUILD_BENCHMARKS=ON
+        -DNEOFOAM_BUILD_BENCHMARKS=ON
 elif [[ "$GPU_VENDOR" == "amd" ]]; then
     cmake --preset $PRESET \
         -DNEOFOAM_NEON_DIR=../NeoN \
@@ -63,7 +63,7 @@ elif [[ "$GPU_VENDOR" == "amd" ]]; then
         -DCMAKE_HIP_ARCHITECTURES=gfx90a \
         -DKokkos_ARCH_AMD_GFX90A=ON \
         -DNeoN_WITH_THREADS=OFF \
-        -DNeoFOAM_BUILD_BENCHMARKS=ON
+        -DNEOFOAM_BUILD_BENCHMARKS=ON
 fi
 
 echo "=== Building NeoFOAM against NeoN ==="

--- a/ci/lrz-gitlab/build-and-test.sh
+++ b/ci/lrz-gitlab/build-and-test.sh
@@ -73,4 +73,4 @@ cmake --build --preset $PRESET
 # Step 3: Run Tests
 # -------------------------
 echo "=== Running NeoFOAM tests ==="
-ctest --preset $PRESET -R adapter --output-on-failure
+ctest --preset $PRESET -E bench --output-on-failure

--- a/ci/lrz-gitlab/build-and-test.sh
+++ b/ci/lrz-gitlab/build-and-test.sh
@@ -54,14 +54,16 @@ if [[ "$GPU_VENDOR" == "nvidia" ]]; then
     cmake --preset $PRESET \
         -DNEOFOAM_NEON_DIR=../NeoN \
         -DCMAKE_CUDA_ARCHITECTURES=90 \
-        -DNeoN_WITH_THREADS=OFF
+        -DNeoN_WITH_THREADS=OFF \
+        -DNeoFOAM_BUILD_BENCHMARKS=ON
 elif [[ "$GPU_VENDOR" == "amd" ]]; then
     cmake --preset $PRESET \
         -DNEOFOAM_NEON_DIR=../NeoN \
         -DCMAKE_CXX_COMPILER=hipcc \
         -DCMAKE_HIP_ARCHITECTURES=gfx90a \
         -DKokkos_ARCH_AMD_GFX90A=ON \
-        -DNeoN_WITH_THREADS=OFF
+        -DNeoN_WITH_THREADS=OFF \
+        -DNeoFOAM_BUILD_BENCHMARKS=ON
 fi
 
 echo "=== Building NeoFOAM against NeoN ==="


### PR DESCRIPTION
In the current CI setup, we do not build benchmarks for CI pipelines by default. It means that the default CI pipelines are not able to capture the failure of benchmark code.

This PR makes the default CI pipelines to build benchmark code additionally.