### PR TITLE
Remove KOKKOS_LAMBDA in favour of NEON_LAMBDA

### DIFF
--- a/benchmarks/bench_explicitOperators.cpp
+++ b/benchmarks/bench_explicitOperators.cpp
@@ -116,10 +116,7 @@ TEST_CASE("DivOperator")
                 NeoN::fill(nfDivT.boundaryData().value(), 0.0);
                 fvcc::GaussGreenDiv<NeoN::scalar>(exec, nfMesh, scheme)
                     .div(nfDivT, nfPhi, nfT, dsl::Coeff(1.0));
-                if (execName == "GPUExecutor")
-                {
-                    Kokkos::fence();
-                }
+                NeoN::fence(exec);
                 return;
             };
         }
@@ -214,10 +211,7 @@ TEST_CASE("LaplacianOperator")
                 NeoN::fill(nfLapT.boundaryData().value(), 0.0);
                 fvcc::GaussGreenLaplacian<NeoN::scalar>(exec, nfMesh, scheme)
                     .laplacian(nfLapT, nfGamma, nfT, dsl::Coeff(1.0));
-                if (execName == "GPUExecutor")
-                {
-                    Kokkos::fence();
-                }
+                NeoN::fence(exec);
                 return;
             };
         }
@@ -284,10 +278,7 @@ TEST_CASE("GradOperator")
                 NeoN::fill(nfGradT.internalVector(), NeoN::Vec3(0, 0, 0));
                 NeoN::fill(nfGradT.boundaryData().value(), NeoN::Vec3(0, 0, 0));
                 fvcc::GaussGreenGrad(exec, nfMesh).grad(nfT, NeoN::dsl::Coeff(), nfGradT);
-                if (execName == "GPUExecutor")
-                {
-                    Kokkos::fence();
-                }
+                NeoN::fence(exec);
                 return;
             };
         }
@@ -396,10 +387,7 @@ TEST_CASE("FaceInterpolation")
             {
                 fvcc::SurfaceInterpolation<NeoN::scalar>(exec, nfMesh, scheme)
                     .interpolate(nfPhi, nfT, nfTf);
-                if (execName == "GPUExecutor")
-                {
-                    Kokkos::fence();
-                }
+                NeoN::fence(exec);
                 return;
             };
         }
@@ -480,10 +468,7 @@ TEST_CASE("FaceNormalGradient")
             {
                 fvcc::FaceNormalGradient<NeoN::scalar>(exec, nfMesh, scheme)
                     .faceNormalGrad(nfT, faceGradT);
-                if (execName == "GPUExecutor")
-                {
-                    Kokkos::fence();
-                }
+                NeoN::fence(exec);
                 return;
             };
         }

--- a/benchmarks/bench_implicitOperators.cpp
+++ b/benchmarks/bench_implicitOperators.cpp
@@ -101,7 +101,7 @@ TEST_CASE("DivOperator")
                 );
                 fvcc::GaussGreenDiv<NeoN::scalar>(exec, nfMesh, scheme)
                     .div(ls, nfPhi, nfT, NeoN::dsl::Coeff(1.0));
-                Kokkos::fence();
+                NeoN::fence(exec);
                 return;
             };
         }
@@ -120,7 +120,7 @@ TEST_CASE("DivOperator")
                 NeoN::fill(ls.rhs(), 0.0);
                 fvcc::GaussGreenDiv<NeoN::scalar>(exec, nfMesh, scheme)
                     .div(ls, nfPhi, nfT, dsl::Coeff(1.0));
-                Kokkos::fence();
+                NeoN::fence(exec);
                 return;
             };
         }
@@ -205,7 +205,7 @@ TEST_CASE("LaplacianOperator")
                 );
                 fvcc::GaussGreenLaplacian<NeoN::scalar>(exec, nfMesh, scheme)
                     .laplacian(ls, nfGamma, nfT, dsl::Coeff(1.0));
-                Kokkos::fence();
+                NeoN::fence(exec);
                 return;
             };
         }
@@ -224,7 +224,7 @@ TEST_CASE("LaplacianOperator")
                 NeoN::fill(ls.rhs(), 0.0);
                 fvcc::GaussGreenLaplacian<NeoN::scalar>(exec, nfMesh, scheme)
                     .laplacian(ls, nfGamma, nfT, dsl::Coeff(1.0));
-                Kokkos::fence();
+                NeoN::fence(exec);
                 return;
             };
         }

--- a/benchmarks/catch_main.hpp
+++ b/benchmarks/catch_main.hpp
@@ -25,58 +25,57 @@ Foam::argList* argsPtr; // Some forks want argList access at createMesh.H
 
 int main(int argc, char* argv[])
 {
-    // Kokkos::initialize(argc, argv);
-    Kokkos::ScopeGuard guard(argc, argv);
-    Catch::Session session;
-
-    // Specify command line options
-    int returnCode = session.applyCommandLine(argc, argv);
-    if (returnCode != 0) // Indicates a command line error
-        return returnCode;
-
-    // Find position of separator "---"
-    int sepIdx = argc - 1;
-    for (int i = 1; i < argc; i++)
+    int result;
+    NeoN::initialize(argc, argv);
     {
-        if (strcmp(argv[i], "---") == 0) sepIdx = i;
-    }
+        Catch::Session session;
 
-    // Figure out argc for each part
-    int doctestArgc = (sepIdx == argc - 1) ? argc : sepIdx;
-    int foamArgc = (sepIdx == argc - 1) ? 1 : argc - sepIdx;
+        // Specify command line options
+        int returnCode = session.applyCommandLine(argc, argv);
+        if (returnCode != 0) // Indicates a command line error
+            return returnCode;
 
-    // Prepare argv for doctestArgv
-    char* doctestArgv[doctestArgc];
-    for (int i = 0; i < doctestArgc; i++)
-    {
-        doctestArgv[i] = argv[i];
-    }
+        // Find position of separator "---"
+        int sepIdx = argc - 1;
+        for (int i = 1; i < argc; i++)
+        {
+            if (strcmp(argv[i], "---") == 0) sepIdx = i;
+        }
 
-    // Prepare argv for OpenFOAM
-    char* foamArgv[foamArgc];
-    foamArgv[0] = argv[0];
-    for (int i = 1; i < foamArgc; i++)
-    {
-        foamArgv[i] = argv[doctestArgc + i];
-    }
+        // Figure out argc for each part
+        int doctestArgc = (sepIdx == argc - 1) ? argc : sepIdx;
+        int foamArgc = (sepIdx == argc - 1) ? 1 : argc - sepIdx;
 
-    // Overwrite argv and argc for Foam include files
-    argc = foamArgc;
-    for (int i = 1; i < foamArgc; i++)
-    {
-        argv[i] = foamArgv[i];
-    }
+        // Prepare argv for doctestArgv
+        char* doctestArgv[doctestArgc];
+        for (int i = 0; i < doctestArgc; i++)
+        {
+            doctestArgv[i] = argv[i];
+        }
+
+        // Prepare argv for OpenFOAM
+        char* foamArgv[foamArgc];
+        foamArgv[0] = argv[0];
+        for (int i = 1; i < foamArgc; i++)
+        {
+            foamArgv[i] = argv[doctestArgc + i];
+        }
+
+        // Overwrite argv and argc for Foam include files
+        argc = foamArgc;
+        for (int i = 1; i < foamArgc; i++)
+        {
+            argv[i] = foamArgv[i];
+        }
 
 #include "setRootCase.H"
 #include "createTime.H"
 
-    argsPtr = &args;
-    timePtr = &runTime;
+        argsPtr = &args;
+        timePtr = &runTime;
 
-    int result = session.run();
-
-    // Run benchmarks if there are any
-    // Kokkos::finalize();
-
+        // Run benchmarks if there are any
+        result = session.run();
+    }
     return result;
 }

--- a/include/NeoFOAM/datastructures/pdeSolver.hpp
+++ b/include/NeoFOAM/datastructures/pdeSolver.hpp
@@ -102,7 +102,7 @@ public:
             NeoN::parallelFor(
                 ls.exec(),
                 {pRefCell_, pRefCell_ + 1},
-                KOKKOS_LAMBDA(const std::size_t refCelli) {
+                NEON_LAMBDA(const std::size_t refCelli) {
                     auto diagIdx = rowOffs[refCelli] + diagOffset[refCelli];
                     auto diagValue = values[diagIdx];
                     rhs[refCelli] += diagValue * pRefValue;
@@ -208,7 +208,7 @@ NeoN::Vector<ValueType> diag(
     NeoN::parallelFor(
         ls.exec(),
         {0, diagOffset.size()},
-        KOKKOS_LAMBDA(const std::size_t celli) {
+        NEON_LAMBDA(const std::size_t celli) {
             auto diagOffsetCelli = diagOffset[celli];
             diagView[celli] = matrix.values[matrix.rowOffs[celli] + diagOffsetCelli];
         }

--- a/src/algorithms/pressureVelocityCoupling.cpp
+++ b/src/algorithms/pressureVelocityCoupling.cpp
@@ -29,7 +29,7 @@ void constrainHbyA(
             parallelFor(
                 hByA.exec(),
                 hByA.boundaryData().range(patchi),
-                KOKKOS_LAMBDA(const size_t bfacei) { hByABcValue[bfacei] = uBcValue[bfacei]; }
+                NEON_LAMBDA(const size_t bfacei) { hByABcValue[bfacei] = uBcValue[bfacei]; }
             );
         }
     }
@@ -53,7 +53,7 @@ nnfvcc::VolumeField<scalar> computeRAU(const PDESolver<Vec3>& expr)
     auto rABCs = nnfvcc::createExtrapolatedBCs<nnfvcc::VolumeBoundary<scalar>>(mesh);
     auto rAU = nnfvcc::VolumeField<scalar>(expr.exec(), "rAU", mesh, rABCs);
 
-    rAU.internalVector().apply(KOKKOS_LAMBDA(const size_t celli) {
+    rAU.internalVector().apply(NEON_LAMBDA(const size_t celli) {
         auto diagOffsetCelli = diagOffset[celli];
         // all the diagonal coefficients are the same
         return vol[celli] / (values[rowPtrs[celli] + diagOffsetCelli][0]);
@@ -96,7 +96,7 @@ computeRAUandHByA(const PDESolver<Vec3>& expr)
     NeoN::parallelFor(
         exec,
         {0, nInternalFaces},
-        KOKKOS_LAMBDA(const size_t facei) {
+        NEON_LAMBDA(const size_t facei) {
             auto own = owner[facei];
             auto nei = neighbour[facei];
 
@@ -106,8 +106,8 @@ computeRAUandHByA(const PDESolver<Vec3>& expr)
             auto lower = values[rowNeiStart + neiOffs[facei]];
             auto upper = values[rowOwnStart + ownOffs[facei]];
 
-            Kokkos::atomic_sub(&internalHbyA[nei], lower[0] * internalU[own]);
-            Kokkos::atomic_sub(&internalHbyA[own], upper[0] * internalU[nei]);
+            NeoN::atomic_sub(&internalHbyA[nei], lower[0] * internalU[own]);
+            NeoN::atomic_sub(&internalHbyA[own], upper[0] * internalU[nei]);
         }
     );
 
@@ -115,7 +115,7 @@ computeRAUandHByA(const PDESolver<Vec3>& expr)
     NeoN::parallelFor(
         exec,
         {0, internalHbyA.size()},
-        KOKKOS_LAMBDA(const size_t celli) {
+        NEON_LAMBDA(const size_t celli) {
             internalHbyA[celli] += rhs[celli];
             internalHbyA[celli] *= internalRAU[celli] / vol[celli];
         }
@@ -157,7 +157,7 @@ void updateFaceVelocity(
     NeoN::parallelFor(
         exec,
         {0, nInternalFaces},
-        KOKKOS_LAMBDA(const size_t facei) {
+        NEON_LAMBDA(const size_t facei) {
             auto own = static_cast<std::size_t>(owner[facei]);
             auto nei = static_cast<std::size_t>(neighbour[facei]);
 
@@ -187,7 +187,7 @@ void updateFaceVelocity(
     NeoN::parallelFor(
         exec,
         {nInternalFaces, iPhi.size()},
-        KOKKOS_LAMBDA(const size_t facei) {
+        NEON_LAMBDA(const size_t facei) {
             auto bfacei = facei - nInternalFaces;
             scalar bflux = (rhsValue[bfacei] - mValue[bfacei] * internalP[faceCells[bfacei]]);
             iPhi[facei] = iPredPhi[facei] - bflux;
@@ -207,7 +207,7 @@ void updateVelocity(
     auto [iHbyA, iRAU, iGradP] =
         views(hByA.internalVector(), rAU.internalVector(), gradP.internalVector());
 
-    u.internalVector().apply(KOKKOS_LAMBDA(const std::size_t celli) {
+    u.internalVector().apply(NEON_LAMBDA(const std::size_t celli) {
         return iHbyA[celli] - iRAU[celli] * iGradP[celli];
     });
 }
@@ -242,7 +242,7 @@ nnfvcc::SurfaceField<scalar> flux(const nnfvcc::VolumeField<Vec3>& volField)
     NeoN::parallelFor(
         exec,
         {0, nInternalFaces},
-        KOKKOS_LAMBDA(const size_t facei) {
+        NEON_LAMBDA(const size_t facei) {
             auto own = static_cast<std::size_t>(owner[facei]);
             auto nei = static_cast<std::size_t>(neighbour[facei]);
 
@@ -255,7 +255,7 @@ nnfvcc::SurfaceField<scalar> flux(const nnfvcc::VolumeField<Vec3>& volField)
     NeoN::parallelFor(
         exec,
         {nInternalFaces, faceFluxIn.size()},
-        KOKKOS_LAMBDA(const size_t facei) {
+        NEON_LAMBDA(const size_t facei) {
             auto faceBCI = facei - nInternalFaces;
 
             faceFluxIn[facei] = bSf[faceBCI] & volFieldBc[faceBCI];

--- a/test/catch2/executorGenerator.hpp
+++ b/test/catch2/executorGenerator.hpp
@@ -9,8 +9,6 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 
-#include <Kokkos_Core.hpp>
-
 #include "NeoN/NeoN.hpp"
 
 #include <string>
@@ -31,16 +29,16 @@ public:
 
     ExecutorGenerator()
     {
-#if defined(KOKKOS_ENABLE_OPENMP)
+#if defined(NEON_ENABLE_OPENMP)
         execs.push_back({"CPUExecutor", NeoN::CPUExecutor {}});
-#elif defined(KOKKOS_ENABLE_THREADS)
+#elif defined(NEON_ENABLE_THREADS)
         execs.push_back({"CPUExecutor", NeoN::CPUExecutor {}});
 #endif
-#if defined(KOKKOS_ENABLE_CUDA)
+#if defined(NEON_ENABLE_CUDA)
         execs.push_back({"GPUExecutor", NeoN::GPUExecutor {}});
-#elif defined(KOKKOS_ENABLE_HIP)
+#elif defined(NEON_ENABLE_HIP)
         execs.push_back({"GPUExecutor", NeoN::GPUExecutor {}});
-#elif defined(KOKKOS_ENABLE_SYCL)
+#elif defined(NEON_ENABLE_SYCL)
         execs.push_back({"GPUExecutor", NeoN::GPUExecutor {}});
 #endif
     }

--- a/test/catch2/test_main.cpp
+++ b/test/catch2/test_main.cpp
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2023 NeoFOAM authors
 
-
-#include "Kokkos_Core.hpp"
-
 #include <catch2/catch_session.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators_all.hpp>
@@ -22,6 +19,7 @@ Foam::fvMesh* meshPtr;  // A single mesh object
 
 int main(int argc, char* argv[])
 {
+    int result;
     NeoN::initialize(argc, argv);
     {
         Catch::Session session;
@@ -72,11 +70,9 @@ int main(int argc, char* argv[])
         argsPtr = &args;
         timePtr = &runTime;
 
-        int result = session.run();
-
         // Run benchmarks if there are any
-        Kokkos::finalize();
-
-        return result;
+        result = session.run();
     }
+    NeoN::finalize();
+    return result;
 }

--- a/test/test_implicitOperators.cpp
+++ b/test/test_implicitOperators.cpp
@@ -52,7 +52,7 @@ TEST_CASE("matrix multiplication")
         const auto nfTOldView = nfTOld.internalVector().view();
         NeoN::map(
             nfTOld.internalVector(),
-            KOKKOS_LAMBDA(const std::size_t celli) { return nfTOldView[celli] - 1.0; }
+            NEON_LAMBDA(const std::size_t celli) { return nfTOldView[celli] - 1.0; }
         );
 
         ofT.oldTime() -= Foam::dimensionedScalar("value", Foam::dimTemperature, 1);
@@ -116,7 +116,7 @@ TEST_CASE("matrix multiplication")
 
         NeoN::map(
             nfT.internalVector(),
-            KOKKOS_LAMBDA(const std::size_t celli) { return celli; }
+            NEON_LAMBDA(const std::size_t celli) { return celli; }
         );
         auto coefficients = nfT;
         NeoN::fill(coefficients.internalVector(), coeff);


### PR DESCRIPTION
NeoFOAM should not depend on NeoNs implementation details, thus this PR removes `KOKKOS_LAMBDA` calls in favour of `NEON_LAMBDA`.