### PR TITLE
Use NVIDIA GPUs other than NVIDIA H100 for CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,8 +4,8 @@
 
 # Available GPUs and corresponding Docker images
 .use-nvidia-gpu-and-image:
-  tags: ["nvidia-h100-gpus"]
-  image: chihtaw/cuda-openfoam-ginkgo:12.8.1-v2412-arch_90
+  tags: ["nvidia-gpus"]
+  image: chihtaw/cuda-openfoam-ginkgo:12.8.1-v2412-arch_89
   variables:
     PYTHONPATH: /root/.local/:/root/.local/lib/:/root/.local/lib/python3.12:/root/.local/lib/python3.12/site-packages
     FOAM_INST_DIR: /usr/local/app/openfoam

--- a/ci/lrz-gitlab/benchmark.sh
+++ b/ci/lrz-gitlab/benchmark.sh
@@ -78,7 +78,6 @@ build_and_benchmark() {
     elif [[ "$GPU_VENDOR" == "amd" ]]; then
         # Set up environment
         export PATH=/opt/rocm/bin:$PATH
-        export HIPCC_CXX=/usr/bin/g++
 
         cmake --preset profiling \
         -DNEOFOAM_NEON_DIR=../NeoN \

--- a/ci/lrz-gitlab/build-and-test.sh
+++ b/ci/lrz-gitlab/build-and-test.sh
@@ -53,7 +53,7 @@ echo "=== Configuring NeoFOAM against NeoN ==="
 if [[ "$GPU_VENDOR" == "nvidia" ]]; then
     cmake --preset $PRESET \
         -DNEOFOAM_NEON_DIR=../NeoN \
-        -DCMAKE_CUDA_ARCHITECTURES=90 \
+        -DCMAKE_CUDA_ARCHITECTURES=89 \
         -DNeoN_WITH_THREADS=OFF \
         -DNEOFOAM_BUILD_BENCHMARKS=ON
 elif [[ "$GPU_VENDOR" == "amd" ]]; then

--- a/ci/lrz-gitlab/build-and-test.sh
+++ b/ci/lrz-gitlab/build-and-test.sh
@@ -27,7 +27,6 @@ if [[ "$GPU_VENDOR" == "nvidia" ]]; then
 elif [[ "$GPU_VENDOR" == "amd" ]]; then
     # Set up environment
     export PATH=/opt/rocm/bin:$PATH
-    export HIPCC_CXX=/usr/bin/g++
 
     echo "=== AMD GPU info ==="
     rocminfo | grep "Marketing Name.*AMD"


### PR DESCRIPTION
Since NV H100 is not available for CI, we need to adapt the CI config to other NV GPUs. Currently, we are using NVIDIA L40S for CI.