### PR TITLE
add dependabot to update submodule version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "cron"
+      cronjob: "00 04 * * *" # need to have 24 hours interval at least
+      timezone: "Europe/Berlin"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Version 0.3.0 ()
+- Update submodule regularly by dependabot [#209](https://github.com/exasim-project/NeoFOAM/pull/209)
 
 ## Fixes
 - Fix spurious bad_any_cast errors when reading fixedValue boundaries [#194](https://github.com/exasim-project/NeoFOAM/pull/194)


### PR DESCRIPTION
It introduces the dependabot to update submodule daily (4am German time) by creating pr.
Dependabot runs on the default branch, so it should not create an update pr for each branch.
If there is newer update before we merge the current dependabot pr, it will auto create a new pr for newer version and auto close the old one.
It should run the pipeline in the pr, but we might need to add the secret used in pipeline in dependabot session.
We will see that from the first dependabot pr.

Note. it does not block the manual version update. 