### PR TITLE
cmake fetches version from submodule and update documentation in proper order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Version 0.3.0 ()
 - Update submodule regularly by dependabot [#209](https://github.com/exasim-project/NeoFOAM/pull/209)
+- Allow auto grabbing version from submodule without initialization and update the documentation [#210](https://github.com/exasim-project/NeoFOAM/pull/210)
 
 ## Fixes
 - Fix spurious bad_any_cast errors when reading fixedValue boundaries [#194](https://github.com/exasim-project/NeoFOAM/pull/194)

--- a/cmake/CxxThirdParty.cmake
+++ b/cmake/CxxThirdParty.cmake
@@ -9,9 +9,27 @@ endif()
 
 if(NEOFOAM_NEON_VIA_CPM)
   if(NOT DEFINED NEOFOAM_NEON_VERSION)
-    set(NEOFOAM_NEON_VERSION
-        "main"
-        CACHE INTERNAL "")
+    # grab the SHA from submodule automatically
+    find_package(Git QUIET)
+    if(EXISTS "${NeoFOAM_SOURCE_DIR}/.git" AND GIT_FOUND)
+      # Note: it will not initialize the submodule and does not require initialization
+      execute_process(
+        COMMAND ${GIT_EXECUTABLE} submodule status "src/NeoN"
+        WORKING_DIRECTORY ${NeoFOAM_SOURCE_DIR}
+        OUTPUT_VARIABLE GIT_SUBMODULE_STRING
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+      # the output format is -<SHA> src/NEON when the submodule uninitialization
+      string(SUBSTRING "${GIT_SUBMODULE_STRING}" 0 1 SUBMODULE_PREFIX)
+      string(SUBSTRING "${GIT_SUBMODULE_STRING}" 1 40 SUBMODULE_HASH)
+      set(NEOFOAM_NEON_VERSION
+          "${SUBMODULE_HASH}"
+          CACHE INTERNAL "")
+    else()
+      # if is is not from git or user does not have git, it fallback to predefined value.
+      set(NEOFOAM_NEON_VERSION
+          "main"
+          CACHE INTERNAL "")
+    endif()
   endif()
 
   cpmaddpackage(

--- a/doc/gettingStarted.rst
+++ b/doc/gettingStarted.rst
@@ -28,7 +28,7 @@ NeoFOAM uses CMake for building. The standard CMake procedure works, but we reco
 Build NeoFOAM Against NeoN
 --------------------------
 
-There are three ways to link NeoFOAM with NeoN:
+There are four ways to build NeoN in NeoFOAM, the checks follows the list order:
 
 1. **Using the NeoN repository directory**
 
@@ -38,7 +38,16 @@ There are three ways to link NeoFOAM with NeoN:
 
       -DNEOFOAM_NEON_DIR=/path/to/NeoN/
 
-2. **Using the NeoN submodule**
+2. **Specifying version of NeoN to download**
+
+   Specify the version to the NeoN repository during CMake configuration and CMake will download the corresponding version:
+   .. code-block:: bash
+
+      -DNEOFOAM_NEON_VERSION=<desired_version>
+
+   `<desired_version>` can be a branch name, tag, or commit hash.
+
+3. **Using the NeoN submodule**
 
    Initialize and update the NeoN submodule in the NeoFOAM repository:
 
@@ -48,15 +57,10 @@ There are three ways to link NeoFOAM with NeoN:
 
    During CMake configuration, the submodule will be automatically detected.
 
-3. **Using automatically downloaded NeoN**
+4. **Using predefined version of NeoN**
 
-   If neither of the above options is provided, CMake will download a predefined version of NeoN. By default, this is the `main` branch. To specify a different version:
-
-   .. code-block:: bash
-
-      -DNEOFOAM_NEON_VERSION=<desired_version>
-
-   `<desired_version>` can be a branch name, tag, or commit hash.
+   If neither of the above options is provided, we will try to grab the version from submodule (without initialization).
+   If auto grabbing does not work due to environment, we will use the predefined version, which is `main` branch for NeoN currently.
 
 Building for GPUs
 -----------------


### PR DESCRIPTION
This PR enable cmake will try to grab the version automatically from submodule if the project is from github not from zip and git is installed in the environment.
If they can not grab the version, it will fallback to the predefined version - main.

Question: should it be main branch from NeoN?

Additionally, I update the documentation in the proper order. The above feature only change the version selection not the order

`NEOFOAM_NEON_DIR` -> `NEOFOAM_NEON_VERSION` -> src/NeoN contains repo (from submodule initialization or not) -> version from submodule SHA or predefined version

After this pr, it mainly changes the user setup without setting branch name. 
Current CI or user needs to specify to develop in the original behavior.