### PR TITLE
Enable developers to skip CI on NVIDIA GPU

### DIFF
--- a/.github/workflows/trigger-lrz-gitlab-ci.yaml
+++ b/.github/workflows/trigger-lrz-gitlab-ci.yaml
@@ -21,6 +21,7 @@ jobs:
 
     outputs:
       branch: ${{ steps.branch.outputs.branch }}
+      skip-nvidia: ${{ steps.skip-nvidia.outputs.skip-nvidia }}
 
     # Only run if the 'Skip-build' label is not present on a PR
     if: "!contains(toJson(github.event.pull_request.labels.*.name), 'Skip-build')"
@@ -49,6 +50,15 @@ jobs:
           fi
           echo "branch=$BRANCH" >> $GITHUB_OUTPUT
 
+      - name: Determine skip-nvidia label
+        id: skip-nvidia
+        run: |
+          if [[ "${{ contains(toJson(github.event.pull_request.labels.*.name), 'skip-nvidia') }}" == "true" ]]; then
+            echo "skip-nvidia=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip-nvidia=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Push commit to LRZ GitLab
         run: |
           git config user.name "github-actions[bot]"
@@ -70,7 +80,8 @@ jobs:
           ./ci/github/trigger_pipeline.sh \
             "${{ steps.branch.outputs.branch }}" \
             "variables[TRIGGER_SOURCE]=${{ github.event.repository.name }}" \
-            "variables[BENCHMARK]=false"
+            "variables[BENCHMARK]=false" \
+            "variables[SKIP_NVIDIA]=${{ steps.skip-nvidia.outputs.skip-nvidia }}"
 
       - name: Wait for LRZ GitLab CI pipeline
         run: |
@@ -89,6 +100,7 @@ jobs:
       LRZ_HOST: gitlab-ce.lrz.de
       REPO_NAME: ${{ github.event.repository.name }}
       BRANCH: ${{ needs.build-and-test.outputs.branch }}
+      SKIP_NVIDIA: ${{ needs.build-and-test.outputs.skip-nvidia }}
       LRZ_GITLAB_PROJECT_TOKEN: ${{ secrets.LRZ_GITLAB_PROJECT_TOKEN }}
       LRZ_GITLAB_TRIGGER_TOKEN: ${{ secrets.LRZ_GITLAB_TRIGGER_TOKEN }}
       MAX_WAIT_MINUTES: 1440
@@ -107,7 +119,8 @@ jobs:
           ./ci/github/trigger_pipeline.sh \
             "${BRANCH}" \
             "variables[TRIGGER_SOURCE]=${{ github.event.repository.name }}" \
-            "variables[BENCHMARK]=true"
+            "variables[BENCHMARK]=true" \
+            "variables[SKIP_NVIDIA]=${SKIP_NVIDIA}"
 
       - name: Wait for LRZ GitLab CI pipeline for benchmarking
         run: |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,24 +77,7 @@
     - which simpleFoam || echo "simpleFoam not found!"
     - find $FOAM_LIBBIN -name "libPstream.so"
 
-# Job rules to determine if the pipeline was triggered from NeoFOAM or NeoN CI
-.trigger-from-neofoam-for-testing:
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "trigger" && $TRIGGER_SOURCE == "NeoFOAM" && $BENCHMARK == "false"
-      when: always
-    - when: never
-
-.trigger-from-neon-for-testing:
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "trigger" && $TRIGGER_SOURCE == "NeoN" && $BENCHMARK == "false"
-      when: always
-    - when: never
-
-.trigger-from-neofoam-for-benchmarking:
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "trigger" && $TRIGGER_SOURCE == "NeoFOAM" && $BENCHMARK == "true"
-      when: always
-    - when: never
+.variables-for-benchmarking:
   variables:
     RESULTS_DIR: "NeoFOAM/${RUN_IDENTIFIER}/${CI_RUNNER_DESCRIPTION}"
     RUN_IDENTIFIER: "${CI_PIPELINE_ID}"
@@ -103,12 +86,50 @@
     TARGET_BRANCH: "ci-benchmarks"
     TARGET_RESULTS_DIR: "NeoFOAM/${RUN_IDENTIFIER}/${CI_RUNNER_DESCRIPTION}"
 
+# --- Configurations of triggering pipelines from NeoFOAM ---
+# For testing
+.trigger-from-neofoam-for-testing-common:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "trigger" && $TRIGGER_SOURCE == "NeoFOAM" && $BENCHMARK == "false"
+      when: always
+    - when: never
+
+.trigger-from-neofoam-for-testing-nvidia:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "trigger" && $TRIGGER_SOURCE == "NeoFOAM" && $BENCHMARK == "false" && $SKIP_NVIDIA == "false"
+      when: always
+    - when: never
+
+# For benchmarking
+.trigger-from-neofoam-for-benchmarking-common:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "trigger" && $TRIGGER_SOURCE == "NeoFOAM" && $BENCHMARK == "true"
+      when: always
+    - when: never
+  extends:
+    - .variables-for-benchmarking
+
+.trigger-from-neofoam-for-benchmarking-nvidia:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "trigger" && $TRIGGER_SOURCE == "NeoFOAM" && $BENCHMARK == "true" && $SKIP_NVIDIA == "false"
+      when: always
+    - when: never
+  extends:
+    - .variables-for-benchmarking
+
+# --- Configurations of triggering pipelines from NeoN ---
+.trigger-from-neon-for-testing:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "trigger" && $TRIGGER_SOURCE == "NeoN" && $BENCHMARK == "false"
+      when: always
+    - when: never
+
 # --- Build and test NeoFOAM with the develop branch of NeoN ---
 build-and-test-triggered-from-NF-nvidia:
   extends:
     - .use-nvidia-gpu-and-image
     - .openfoam-env-setup
-    - .trigger-from-neofoam-for-testing
+    - .trigger-from-neofoam-for-testing-nvidia
   script:
     - ./ci/lrz-gitlab/build-and-test.sh nvidia $NEON_BRANCH
 
@@ -116,14 +137,14 @@ build-and-test-triggered-from-NF-amd:
   extends:
     - .use-amd-gpu-and-image
     - .openfoam-env-setup
-    - .trigger-from-neofoam-for-testing
+    - .trigger-from-neofoam-for-testing-common
   script:
     - ./ci/lrz-gitlab/build-and-test.sh amd $NEON_BRANCH
 
 build-and-test-triggered-from-NF-intel:
   extends:
     - .use-intel-gpu-and-image
-    - .trigger-from-neofoam-for-testing
+    - .trigger-from-neofoam-for-testing-common
   script:
     - ./ci/lrz-gitlab/build-and-test.sh intel $NEON_BRANCH
 
@@ -132,7 +153,7 @@ benchmark-triggered-from-NF-nvidia:
   extends:
     - .use-nvidia-gpu-and-image
     - .openfoam-env-setup
-    - .trigger-from-neofoam-for-benchmarking
+    - .trigger-from-neofoam-for-benchmarking-nvidia
   script:
     - ./ci/lrz-gitlab/benchmark.sh nvidia $NEON_BRANCH profiling
 
@@ -140,14 +161,14 @@ benchmark-triggered-from-NF-amd:
   extends:
     - .use-amd-gpu-and-image
     - .openfoam-env-setup
-    - .trigger-from-neofoam-for-benchmarking
+    - .trigger-from-neofoam-for-benchmarking-common
   script:
     - ./ci/lrz-gitlab/benchmark.sh amd $NEON_BRANCH profiling
 
 benchmark-and-test-triggered-from-NF-intel:
   extends:
     - .use-intel-gpu-and-image
-    - .trigger-from-neofoam-for-benchmarking
+    - .trigger-from-neofoam-for-benchmarking-common
   script:
     - ./ci/lrz-gitlab/build-and-test.sh intel $NEON_BRANCH profiling
 


### PR DESCRIPTION
When NVIDIA GPUs are not available for CI for quite a period of time, developers might want to skip CI on NVIDIA GPUs.
This PR enables skipping CI on NVIDIA GPUs by adding the label `skip-nvidia` to the PR.