### PR TITLE
Enable skipping of CI on AMD or Intel GPUs

### DIFF
--- a/.github/workflows/trigger-lrz-gitlab-ci.yaml
+++ b/.github/workflows/trigger-lrz-gitlab-ci.yaml
@@ -22,6 +22,7 @@ jobs:
     outputs:
       branch: ${{ steps.branch.outputs.branch }}
       skip-nvidia: ${{ steps.skip-nvidia.outputs.skip-nvidia }}
+      skip-intel: ${{ steps.skip-intel.outputs.skip-intel }}
 
     # Only run if the 'Skip-build' label is not present on a PR
     if: "!contains(toJson(github.event.pull_request.labels.*.name), 'Skip-build')"
@@ -59,6 +60,15 @@ jobs:
             echo "skip-nvidia=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Determine skip-intel label
+        id: skip-intel
+        run: |
+          if [[ "${{ contains(toJson(github.event.pull_request.labels.*.name), 'skip-intel') }}" == "true" ]]; then
+            echo "skip-intel=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip-intel=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Push commit to LRZ GitLab
         run: |
           git config user.name "github-actions[bot]"
@@ -81,7 +91,8 @@ jobs:
             "${{ steps.branch.outputs.branch }}" \
             "variables[TRIGGER_SOURCE]=${{ github.event.repository.name }}" \
             "variables[BENCHMARK]=false" \
-            "variables[SKIP_NVIDIA]=${{ steps.skip-nvidia.outputs.skip-nvidia }}"
+            "variables[SKIP_NVIDIA]=${{ steps.skip-nvidia.outputs.skip-nvidia }}" \
+            "variables[SKIP_INTEL]=${{ steps.skip-intel.outputs.skip-intel }}"
 
       - name: Wait for LRZ GitLab CI pipeline
         run: |
@@ -101,6 +112,7 @@ jobs:
       REPO_NAME: ${{ github.event.repository.name }}
       BRANCH: ${{ needs.build-and-test.outputs.branch }}
       SKIP_NVIDIA: ${{ needs.build-and-test.outputs.skip-nvidia }}
+      SKIP_INTEL: ${{ needs.build-and-test.outputs.skip-intel }}
       LRZ_GITLAB_PROJECT_TOKEN: ${{ secrets.LRZ_GITLAB_PROJECT_TOKEN }}
       LRZ_GITLAB_TRIGGER_TOKEN: ${{ secrets.LRZ_GITLAB_TRIGGER_TOKEN }}
       MAX_WAIT_MINUTES: 1440
@@ -120,7 +132,8 @@ jobs:
             "${BRANCH}" \
             "variables[TRIGGER_SOURCE]=${{ github.event.repository.name }}" \
             "variables[BENCHMARK]=true" \
-            "variables[SKIP_NVIDIA]=${SKIP_NVIDIA}"
+            "variables[SKIP_NVIDIA]=${SKIP_NVIDIA}" \
+            "variables[SKIP_INTEL]=${SKIP_INTEL}"
 
       - name: Wait for LRZ GitLab CI pipeline for benchmarking
         run: |

--- a/.github/workflows/trigger-lrz-gitlab-ci.yaml
+++ b/.github/workflows/trigger-lrz-gitlab-ci.yaml
@@ -22,6 +22,7 @@ jobs:
     outputs:
       branch: ${{ steps.branch.outputs.branch }}
       skip-nvidia: ${{ steps.skip-nvidia.outputs.skip-nvidia }}
+      skip-amd: ${{ steps.skip-amd.outputs.skip-amd }}
       skip-intel: ${{ steps.skip-intel.outputs.skip-intel }}
 
     # Only run if the 'Skip-build' label is not present on a PR
@@ -60,6 +61,15 @@ jobs:
             echo "skip-nvidia=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Determine skip-amd label
+        id: skip-amd
+        run: |
+          if [[ "${{ contains(toJson(github.event.pull_request.labels.*.name), 'skip-amd') }}" == "true" ]]; then
+            echo "skip-amd=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip-amd=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Determine skip-intel label
         id: skip-intel
         run: |
@@ -92,6 +102,7 @@ jobs:
             "variables[TRIGGER_SOURCE]=${{ github.event.repository.name }}" \
             "variables[BENCHMARK]=false" \
             "variables[SKIP_NVIDIA]=${{ steps.skip-nvidia.outputs.skip-nvidia }}" \
+            "variables[SKIP_AMD]=${{ steps.skip-amd.outputs.skip-amd }}" \
             "variables[SKIP_INTEL]=${{ steps.skip-intel.outputs.skip-intel }}"
 
       - name: Wait for LRZ GitLab CI pipeline
@@ -112,6 +123,7 @@ jobs:
       REPO_NAME: ${{ github.event.repository.name }}
       BRANCH: ${{ needs.build-and-test.outputs.branch }}
       SKIP_NVIDIA: ${{ needs.build-and-test.outputs.skip-nvidia }}
+      SKIP_AMD: ${{ needs.build-and-test.outputs.skip-amd }}
       SKIP_INTEL: ${{ needs.build-and-test.outputs.skip-intel }}
       LRZ_GITLAB_PROJECT_TOKEN: ${{ secrets.LRZ_GITLAB_PROJECT_TOKEN }}
       LRZ_GITLAB_TRIGGER_TOKEN: ${{ secrets.LRZ_GITLAB_TRIGGER_TOKEN }}
@@ -133,6 +145,7 @@ jobs:
             "variables[TRIGGER_SOURCE]=${{ github.event.repository.name }}" \
             "variables[BENCHMARK]=true" \
             "variables[SKIP_NVIDIA]=${SKIP_NVIDIA}" \
+            "variables[SKIP_AMD]=${SKIP_AMD}" \
             "variables[SKIP_INTEL]=${SKIP_INTEL}"
 
       - name: Wait for LRZ GitLab CI pipeline for benchmarking

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -88,30 +88,44 @@
 
 # --- Configurations of triggering pipelines from NeoFOAM ---
 # For testing
-.trigger-from-neofoam-for-testing-common:
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "trigger" && $TRIGGER_SOURCE == "NeoFOAM" && $BENCHMARK == "false"
-      when: always
-    - when: never
-
 .trigger-from-neofoam-for-testing-nvidia:
   rules:
     - if: $CI_PIPELINE_SOURCE == "trigger" && $TRIGGER_SOURCE == "NeoFOAM" && $BENCHMARK == "false" && $SKIP_NVIDIA == "false"
       when: always
     - when: never
 
-# For benchmarking
-.trigger-from-neofoam-for-benchmarking-common:
+.trigger-from-neofoam-for-testing-amd:
   rules:
-    - if: $CI_PIPELINE_SOURCE == "trigger" && $TRIGGER_SOURCE == "NeoFOAM" && $BENCHMARK == "true"
+    - if: $CI_PIPELINE_SOURCE == "trigger" && $TRIGGER_SOURCE == "NeoFOAM" && $BENCHMARK == "false" && $SKIP_AMD == "false"
+      when: always
+    - when: never
+
+.trigger-from-neofoam-for-testing-intel:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "trigger" && $TRIGGER_SOURCE == "NeoFOAM" && $BENCHMARK == "false" && $SKIP_INTEL == "false"
+      when: always
+    - when: never
+
+# For benchmarking
+.trigger-from-neofoam-for-benchmarking-nvidia:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "trigger" && $TRIGGER_SOURCE == "NeoFOAM" && $BENCHMARK == "true" && $SKIP_NVIDIA == "false"
       when: always
     - when: never
   extends:
     - .variables-for-benchmarking
 
-.trigger-from-neofoam-for-benchmarking-nvidia:
+.trigger-from-neofoam-for-benchmarking-amd:
   rules:
-    - if: $CI_PIPELINE_SOURCE == "trigger" && $TRIGGER_SOURCE == "NeoFOAM" && $BENCHMARK == "true" && $SKIP_NVIDIA == "false"
+    - if: $CI_PIPELINE_SOURCE == "trigger" && $TRIGGER_SOURCE == "NeoFOAM" && $BENCHMARK == "true" && $SKIP_AMD == "false"
+      when: always
+    - when: never
+  extends:
+    - .variables-for-benchmarking
+
+.trigger-from-neofoam-for-benchmarking-intel:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "trigger" && $TRIGGER_SOURCE == "NeoFOAM" && $BENCHMARK == "true" && $SKIP_INTEL == "false"
       when: always
     - when: never
   extends:
@@ -124,7 +138,7 @@
       when: always
     - when: never
 
-# --- Build and test NeoFOAM with the develop branch of NeoN ---
+# --- Build and test NeoFOAM ---
 build-and-test-triggered-from-NF-nvidia:
   extends:
     - .use-nvidia-gpu-and-image
@@ -137,18 +151,18 @@ build-and-test-triggered-from-NF-amd:
   extends:
     - .use-amd-gpu-and-image
     - .openfoam-env-setup
-    - .trigger-from-neofoam-for-testing-common
+    - .trigger-from-neofoam-for-testing-amd
   script:
     - ./ci/lrz-gitlab/build-and-test.sh amd $NEON_BRANCH
 
 build-and-test-triggered-from-NF-intel:
   extends:
     - .use-intel-gpu-and-image
-    - .trigger-from-neofoam-for-testing-common
+    - .trigger-from-neofoam-for-testing-intel
   script:
     - ./ci/lrz-gitlab/build-and-test.sh intel $NEON_BRANCH
 
-# --- Benchmark NeoFOAM with the develop branch of NeoN ---
+# --- Benchmark NeoFOAM ---
 benchmark-triggered-from-NF-nvidia:
   extends:
     - .use-nvidia-gpu-and-image
@@ -161,14 +175,14 @@ benchmark-triggered-from-NF-amd:
   extends:
     - .use-amd-gpu-and-image
     - .openfoam-env-setup
-    - .trigger-from-neofoam-for-benchmarking-common
+    - .trigger-from-neofoam-for-benchmarking-amd
   script:
     - ./ci/lrz-gitlab/benchmark.sh amd $NEON_BRANCH
 
 benchmark-and-test-triggered-from-NF-intel:
   extends:
     - .use-intel-gpu-and-image
-    - .trigger-from-neofoam-for-benchmarking-common
+    - .trigger-from-neofoam-for-benchmarking-intel
   script:
     - ./ci/lrz-gitlab/build-and-test.sh intel $NEON_BRANCH
 

--- a/ci/lrz-gitlab/build-and-test.sh
+++ b/ci/lrz-gitlab/build-and-test.sh
@@ -32,6 +32,7 @@ elif [[ "$GPU_VENDOR" == "amd" ]]; then
     rocminfo | grep "Marketing Name.*AMD"
     echo "=== AMD compiler driver info ==="
     hipcc --version
+
 elif [[ "$GPU_VENDOR" == "intel" ]]; then
     if ! sycl-ls --ignore-device-selectors 2>/dev/null | grep -qi intel; then
         echo "No Intel GPU found or Level Zero runtime not available"


### PR DESCRIPTION
This PR enables developers to skip LRZ GitLab CI on AMD or Intel GPUs by adding the corresponding PR label to their PRs.

The PR label used to skip CI on GPUs:
- `skip-amd` for AMD GPU
- `skip-intel` for Intel GPU