### PR TITLE
Update Intel docker-image with pre-installed ginkgo

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@
 
 .use-intel-gpu-and-image:
   tags: ["intel-gpus"]
-  image: dheerajraghunathan/oneapi-openfoam:2025.3-v2412-arch_pvc
+  image: dheerajraghunathan/oneapi-openfoam-ginkgo:2025.3-v2412-arch_pvc
   before_script:
     - source /opt/intel/oneapi/setvars.sh --force
     - eval "$(bash -c 'source /opt/openfoam/OpenFOAM-v2412/etc/bashrc >/dev/null 2>&1; export -p')"


### PR DESCRIPTION
This PR updates the docker image for intel. Ginkgo 1.11.0 is pre-installed.