### PR TITLE
Version update does not need doc and changelog

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
       interval: "cron"
       cronjob: "00 04 * * *" # need to have 24 hours interval at least
       timezone: "Europe/Berlin"
+    labels:
+      - "skip-changelog"

--- a/.github/workflows/build_doc.yaml
+++ b/.github/workflows/build_doc.yaml
@@ -37,7 +37,7 @@ jobs:
 
     # 1. PREVIEW BUILD (per PR)
     - name: Deploy PR Build
-      if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.merged }}
+      if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.merged && github.event.pull_request.user.login != 'dependabot[bot]' }}
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         folder: docs_build


### PR DESCRIPTION
Dependabot version update does not need doc and changelog because nothing change in this repo.