### PR TITLE
Fix/solver settings

### DIFF
--- a/examples/neoIcoFoam/neoIcoFoam.cpp
+++ b/examples/neoIcoFoam/neoIcoFoam.cpp
@@ -49,7 +49,7 @@ int main(int argc, char* argv[])
             fvcc::VectorCollection::instance(rt.db, "VectorCollection");
 
         auto& p = nf::constructAndRegister(vectorCollection, rt, ofP, false);
-        auto& U = nf::constructAndRegister(vectorCollection, rt, ofU);
+        auto& U = nf::constructAndRegister(vectorCollection, rt, ofU, false);
 
         auto nuBCs = fvcc::createCalculatedBCs<fvcc::SurfaceBoundary<NeoN::scalar>>(rt.nfMesh);
         fvcc::SurfaceField<NeoN::scalar> nu(rt.exec, "nu", rt.nfMesh, nuBCs);
@@ -57,7 +57,7 @@ int main(int argc, char* argv[])
         NeoN::fill(nu.boundaryData().value(), viscosity.value());
 
         NeoN::Logging::info("Creating phi");
-        auto& phi = nf::constructAndRegister(vectorCollection, rt, ofPhi);
+        auto& phi = nf::constructAndRegister(vectorCollection, rt, ofPhi, false);
 
         // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 

--- a/src/compatibility/fvSolution.cpp
+++ b/src/compatibility/fvSolution.cpp
@@ -136,7 +136,7 @@ void updateCriteria(NeoN::Dictionary& solverDict)
     if (solverDict.contains("relTol"))
     {
         NeoN::Dictionary& criteriaDict = solverDict.subDict("criteria");
-        criteriaDict.insert("relative_residual_norm", extractScalar(solverDict, "relTol"));
+        criteriaDict.insert("initial_residual_norm", extractScalar(solverDict, "relTol"));
     }
     if (solverDict.contains("maxIter"))
     {


### PR DESCRIPTION
Mapping relTol to "relative_residual_norm" is wrong the correct behaviour is recovered by "initial_residual_norm".
Also when using BDF2, the startup phase where BDF1 is used is detected via the number of old time rotations. Thus the fields mustn't be rotated on registration.