### PR TITLE
Enable mempool

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: cmake-format
       - id: cmake-lint
   - repo: https://github.com/fsfe/reuse-tool
-    rev: v4.0.2
+    rev: v6.2.0
     hooks:
       - id: reuse
   - repo: https://github.com/crate-ci/typos

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# Version 0.3.0 ()
+# Version 0.3.0 (unreleased)
+- Enable mempool via controlDict [#246](https://github.com/exasim-project/NeoFOAM/pull/246)
+
+## Development
 - Update submodule regularly by dependabot [#209](https://github.com/exasim-project/NeoFOAM/pull/209)
 - Allow auto grabbing version from submodule without initialization and update the documentation [#210](https://github.com/exasim-project/NeoFOAM/pull/210)
 

--- a/examples/neoIcoFoam/createNFTime.H
+++ b/examples/neoIcoFoam/createNFTime.H
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
-// SPDX-FileCopyrightText: 2025 NeoFOAM authors
-
-NeoFOAM::Executor exec = createExecutor(runTime.controlDict());
-std::unique_ptr<Foam::MeshAdapter> meshPtr = Foam::createMesh(exec, runTime);
-Foam::MeshAdapter& mesh = *meshPtr;

--- a/examples/neoIcoFoam/neoIcoFoam.cpp
+++ b/examples/neoIcoFoam/neoIcoFoam.cpp
@@ -39,6 +39,7 @@ int main(int argc, char* argv[])
 
 #include "createFields.H"
 
+
         auto& solverDict = rt.fvSolutionDict.subDict("solvers");
         solverDict.subDict("p") = nf::mapFvSolution(solverDict.subDict("p"));
         solverDict.subDict("U") = nf::mapFvSolution(solverDict.subDict("U"));

--- a/src/auxiliary/setup.cpp
+++ b/src/auxiliary/setup.cpp
@@ -55,23 +55,30 @@ std::unique_ptr<Foam::fvMesh> createMesh(const Foam::Time& runTime)
 /* @brief create a NeoN executor from a name
  * @return the Neon::Executor
  */
-NeoN::Executor createExecutor(const std::string execName)
+NeoN::Executor
+createExecutor(const std::string execName, std::unique_ptr<NeoN::AllocatorStrategy> strategy)
 {
     NeoN::Logging::info("Creating Executor {}", execName);
     if (execName == "Serial")
     {
-        return NeoN::SerialExecutor();
+        return NeoN::SerialExecutor(std::move(strategy));
     }
     if (execName == "CPU")
     {
-        return NeoN::CPUExecutor();
+        return NeoN::CPUExecutor(std::move(strategy));
     }
     if (execName == "GPU")
     {
-        return NeoN::GPUExecutor();
+        return NeoN::GPUExecutor(std::move(strategy));
     }
+    if (execName == "default")
+    {
+        return NeoN::createDefaultExecutor(std::move(strategy));
+    }
+
+
     Foam::FatalError << "unknown Executor: " << execName << Foam::nl
-                     << "Available executors: Serial, CPU, GPU" << Foam::nl
+                     << "Available executors: Serial, CPU, GPU, default" << Foam::nl
                      << Foam::abort(Foam::FatalError);
 
     return NeoN::SerialExecutor();
@@ -80,7 +87,19 @@ NeoN::Executor createExecutor(const std::string execName)
 NeoN::Executor createExecutor(const Foam::dictionary& dict)
 {
     auto execName = std::string(dict.get<Foam::word>("executor"));
-    return createExecutor(execName);
+    auto allocator = std::string(dict.get<Foam::word>("allocator"));
+    if (allocator == "Umpire")
+    {
+        return createExecutor(execName, std::make_unique<NeoN::UmpireAllocator>());
+    }
+    if (allocator == "UmpirePool")
+    {
+        // TODO allow percentual pool size
+        auto poolSizeGB = Foam::scalar(dict.get<Foam::scalar>("memPoolSize"));
+        NeoN::UmpireMempoolHandler::setupUmpirePool(NeoN::MemorySpace::GPU, poolSizeGB * 1e9);
+        return createExecutor(execName, std::make_unique<NeoN::UmpirePoolAllocator>());
+    }
+    return createExecutor(execName, std::make_unique<NeoN::DefaultAllocator>());
 }
 
 NeoFOAM::RunTime createAdapterRunTime(const Foam::Time& in)

--- a/tutorials/cylinder2D/system/controlDict
+++ b/tutorials/cylinder2D/system/controlDict
@@ -18,6 +18,10 @@ application     icoFoam;
 
 executor        GPU;
 
+allocator       UmpirePool;
+
+memPoolSize     1.0; // requested pool size in GB
+
 startFrom       startTime;
 
 startTime       0;


### PR DESCRIPTION
This PR enable umpire pool creation support in neoIcoFOAM and adds an example for the cylinder2D case.

To use the mempool compile with `-DNeoN_WITH_UMPIRE=ON` and add the following to a controlDict.

```
allocator            UmpirePool;
memPoolSize    2; // requested pool size in GB
```

Additional changes:
- bump reuse version