### PR TITLE
Fix fmt error on AMD

### DIFF
--- a/ci/lrz-gitlab/benchmark.sh
+++ b/ci/lrz-gitlab/benchmark.sh
@@ -78,28 +78,35 @@ build_and_benchmark() {
     echo ">>> Configuring build"
     if [[ "$GPU_VENDOR" == "nvidia" ]]; then
         cmake --preset $PRESET \
-        -DNEOFOAM_NEON_DIR=../NeoN \
-        -DCMAKE_CUDA_ARCHITECTURES=90 \
-        -DNeoN_WITH_THREADS=ON
+            -DNEOFOAM_NEON_DIR=../NeoN \
+            -DCMAKE_CUDA_ARCHITECTURES=90 \
+            -DNeoN_WITH_THREADS=ON
     elif [[ "$GPU_VENDOR" == "amd" ]]; then
         # Set up environment
-        export PATH=/opt/rocm/bin:$PATH
+        export CXX_COMPILER_PATH="$(which g++)"
+        export CXX_SOURCE="${CXX_COMPILER_PATH%/*/*}"
+        export CXX_LIBDIR="${CXX_SOURCE}/lib64"
+        export LD_LIBRARY_PATH=${CXX_LIBDIR}:${LD_LIBRARY_PATH}
 
         cmake --preset $PRESET \
-        -DNEOFOAM_NEON_DIR=../NeoN \
-        -DCMAKE_CXX_COMPILER=hipcc \
-        -DCMAKE_HIP_ARCHITECTURES=gfx90a \
-        -DKokkos_ARCH_AMD_GFX90A=ON \
-        -DNeoN_WITH_THREADS=ON
+            -DNEOFOAM_NEON_DIR=../NeoN \
+            -DCMAKE_PREFIX_PATH=/opt/rocm \
+            -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang \
+            -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ \
+            -DCMAKE_CXX_FLAGS="--gcc-toolchain=${CXX_SOURCE}" \
+            -DCMAKE_EXE_LINKER_FLAGS="-L${CXX_LIBDIR}" \
+            -DCMAKE_HIP_ARCHITECTURES=gfx90a \
+            -DKokkos_ARCH_AMD_GFX90A=ON \
+            -DNeoN_WITH_THREADS=ON
     elif [[ "$GPU_VENDOR" == "intel" ]]; then
         cmake --preset $PRESET \
-        -DNEOFOAM_NEON_DIR=../NeoN \
-        -DCMAKE_CXX_COMPILER=icpx \
-        -DCMAKE_CXX_FLAGS="-Wno-deprecated-declarations -Wno-sycl-2020-compat -ffp-model=precise" \
-        -DKokkos_ENABLE_SYCL=ON \
-        -DNeoN_WITH_THREADS=ON \
-        -DNEOFOAM_BENCHMARK_MODE="fast" \
-        -DCMAKE_BUILD_TYPE="release"
+            -DNEOFOAM_NEON_DIR=../NeoN \
+            -DCMAKE_CXX_COMPILER=icpx \
+            -DCMAKE_CXX_FLAGS="-Wno-deprecated-declarations -Wno-sycl-2020-compat -ffp-model=precise" \
+            -DKokkos_ENABLE_SYCL=ON \
+            -DNeoN_WITH_THREADS=ON \
+            -DNEOFOAM_BENCHMARK_MODE="fast" \
+            -DCMAKE_BUILD_TYPE="release"
     else
         cmake --preset $PRESET -DNEOFOAM_NEON_DIR=../NeoN -DNeoN_WITH_THREADS=OFF
     fi

--- a/ci/lrz-gitlab/build-and-test.sh
+++ b/ci/lrz-gitlab/build-and-test.sh
@@ -26,7 +26,10 @@ if [[ "$GPU_VENDOR" == "nvidia" ]]; then
 
 elif [[ "$GPU_VENDOR" == "amd" ]]; then
     # Set up environment
-    export PATH=/opt/rocm/bin:$PATH
+    export CXX_COMPILER_PATH="$(which g++)"
+    export CXX_SOURCE="${CXX_COMPILER_PATH%/*/*}"
+    export CXX_LIBDIR="${CXX_SOURCE}/lib64"
+    export LD_LIBRARY_PATH=${CXX_LIBDIR}:${LD_LIBRARY_PATH}
 
     echo "=== AMD GPU info ==="
     rocminfo | grep "Marketing Name.*AMD"
@@ -67,10 +70,15 @@ if [[ "$GPU_VENDOR" == "nvidia" ]]; then
 elif [[ "$GPU_VENDOR" == "amd" ]]; then
     cmake --preset $PRESET \
         -DNEOFOAM_NEON_DIR=../NeoN \
-        -DCMAKE_CXX_COMPILER=hipcc \
+        -DCMAKE_PREFIX_PATH=/opt/rocm \
+        -DCMAKE_C_COMPILER=/opt/rocm/llvm/bin/clang \
+        -DCMAKE_CXX_COMPILER=/opt/rocm/llvm/bin/clang++ \
+        -DCMAKE_CXX_FLAGS="--gcc-toolchain=${CXX_SOURCE}" \
+        -DCMAKE_EXE_LINKER_FLAGS="-L${CXX_LIBDIR}" \
         -DCMAKE_HIP_ARCHITECTURES=gfx90a \
         -DKokkos_ARCH_AMD_GFX90A=ON \
-        -DNeoN_WITH_THREADS=OFF
+        -DNeoN_WITH_THREADS=OFF \
+        -DNEOFOAM_BUILD_BENCHMARKS=ON
 elif [[ "$GPU_VENDOR" == "intel" ]]; then
     cmake --preset $PRESET \
         -DNEOFOAM_NEON_DIR=../NeoN \


### PR DESCRIPTION
This PR fixes a build issue on AMD caused by using hipcc as the global C++ compiler. That configuration caused dependencies like `fmt` to trigger errors during device compilation, as shown below.

`error: reference to __host__ function 'assert_fail' in __host__ __device__ function`.

Also, added `-DNEOFOAM_BUILD_BENCHMARKS=ON` for the build and test step. This was missing for AMD GPUs.