### PR TITLE
Fix NFS filesystem error of removing output directories in unit tests

### DIFF
--- a/test/test_forceCoeffs.cpp
+++ b/test/test_forceCoeffs.cpp
@@ -78,16 +78,16 @@ struct OfForcesSetup
 
     explicit OfForcesSetup(Foam::fvMesh& mesh, const Foam::Time& runTime, Foam::scalar nu = 0.0)
         : zeroU(
-              Foam::IOobject(
-                  "U",
-                  runTime.timeName(),
-                  mesh,
-                  Foam::IOobject::NO_READ,
-                  Foam::IOobject::NO_WRITE
-              ),
-              mesh,
-              Foam::dimensionedVector("U", Foam::dimVelocity, Foam::vector::zero)
-          )
+            Foam::IOobject(
+                "U",
+                runTime.timeName(),
+                mesh,
+                Foam::IOobject::NO_READ,
+                Foam::IOobject::NO_WRITE
+            ),
+            mesh,
+            Foam::dimensionedVector("U", Foam::dimVelocity, Foam::vector::zero)
+        )
         , transportProps(Foam::IOobject(
               "transportProperties",
               runTime.constant(),

--- a/test/test_forceCoeffs.cpp
+++ b/test/test_forceCoeffs.cpp
@@ -78,16 +78,16 @@ struct OfForcesSetup
 
     explicit OfForcesSetup(Foam::fvMesh& mesh, const Foam::Time& runTime, Foam::scalar nu = 0.0)
         : zeroU(
-            Foam::IOobject(
-                "U",
-                runTime.timeName(),
-                mesh,
-                Foam::IOobject::NO_READ,
-                Foam::IOobject::NO_WRITE
-            ),
-            mesh,
-            Foam::dimensionedVector("U", Foam::dimVelocity, Foam::vector::zero)
-        )
+              Foam::IOobject(
+                  "U",
+                  runTime.timeName(),
+                  mesh,
+                  Foam::IOobject::NO_READ,
+                  Foam::IOobject::NO_WRITE
+              ),
+              mesh,
+              Foam::dimensionedVector("U", Foam::dimVelocity, Foam::vector::zero)
+          )
         , transportProps(Foam::IOobject(
               "transportProperties",
               runTime.constant(),
@@ -113,64 +113,71 @@ TEST_CASE("Forces - pressure force and moment match OpenFOAM reference")
         fs::remove_all("postProcessing/neoForces");
         fs::remove_all("postProcessing/ofForces");
 
-        auto rt = nf::createAdapterRunTime(runTime, exec);
-        auto& mesh = rt.mesh;
+        {
+            auto rt = nf::createAdapterRunTime(runTime, exec);
+            auto& mesh = rt.mesh;
 
-        Foam::volScalarField ofP(
-            Foam::IOobject(
-                "p",
-                runTime.timeName(),
-                mesh,
-                Foam::IOobject::MUST_READ,
-                Foam::IOobject::NO_WRITE
-            ),
-            mesh
-        );
-        ofP.primitiveFieldRef() = Foam::scalar {1.0};
-        ofP.correctBoundaryConditions();
+            Foam::volScalarField ofP(
+                Foam::IOobject(
+                    "p",
+                    runTime.timeName(),
+                    mesh,
+                    Foam::IOobject::MUST_READ,
+                    Foam::IOobject::NO_WRITE
+                ),
+                mesh
+            );
+            ofP.primitiveFieldRef() = Foam::scalar {1.0};
+            ofP.correctBoundaryConditions();
 
-        fvcc::VectorCollection& vc = fvcc::VectorCollection::instance(rt.db, "VectorCollection");
-        nf::constructAndRegister(vc, rt, ofP, false);
+            fvcc::VectorCollection& vc =
+                fvcc::VectorCollection::instance(rt.db, "VectorCollection");
+            nf::constructAndRegister(vc, rt, ofP, false);
 
-        // ── NeoFOAM Forces ───────────────────────────────────────────────────
-        Foam::dictionary dict;
-        dict.add("patches", Foam::wordList {"fixedWalls"});
-        dict.add("pName", Foam::word {"p"});
-        dict.add("rhoInf", Foam::scalar {1.0});
-        dict.add("pRef", Foam::scalar {0.0});
-        dict.add("CofR", Foam::vector(0, 0, 0));
+            // ── NeoFOAM Forces ───────────────────────────────────────────────────
+            Foam::dictionary dict;
+            dict.add("patches", Foam::wordList {"fixedWalls"});
+            dict.add("pName", Foam::word {"p"});
+            dict.add("rhoInf", Foam::scalar {1.0});
+            dict.add("pRef", Foam::scalar {0.0});
+            dict.add("CofR", Foam::vector(0, 0, 0));
 
-        nf::Forces forces("neoForces", runTime, dict);
-        REQUIRE(forces.execute());
-        REQUIRE(forces.write());
+            nf::Forces forces("neoForces", runTime, dict);
+            REQUIRE(forces.execute());
+            REQUIRE(forces.write());
 
-        // ── OF forces reference ──────────────────────────────────────────────
-        OfForcesSetup ofSetup(mesh, runTime);
+            // ── OF forces reference ──────────────────────────────────────────────
+            OfForcesSetup ofSetup(mesh, runTime);
 
-        Foam::dictionary ofDict;
-        ofDict.add("patches", Foam::wordList {"fixedWalls"});
-        ofDict.add("rho", Foam::word("rhoInf"));
-        ofDict.add("rhoInf", Foam::scalar {1.0});
-        ofDict.add("pRef", Foam::scalar {0.0});
-        ofDict.add("CofR", Foam::vector(0, 0, 0));
+            Foam::dictionary ofDict;
+            ofDict.add("patches", Foam::wordList {"fixedWalls"});
+            ofDict.add("rho", Foam::word("rhoInf"));
+            ofDict.add("rhoInf", Foam::scalar {1.0});
+            ofDict.add("pRef", Foam::scalar {0.0});
+            ofDict.add("CofR", Foam::vector(0, 0, 0));
 
-        Foam::functionObjects::forces ofForces("ofForces", runTime, ofDict);
-        REQUIRE(ofForces.execute());
-        REQUIRE(ofForces.write());
+            Foam::functionObjects::forces ofForces("ofForces", runTime, ofDict);
+            REQUIRE(ofForces.execute());
+            REQUIRE(ofForces.write());
+        }
 
         // ── File comparison ──────────────────────────────────────────────────
+        INFO("Comparing NeoFOAM and OpenFOAM force output files");
         const double tol = 1e-10;
         compareDataFiles(
             "postProcessing/neoForces/0/force.dat",
             "postProcessing/ofForces/0/force.dat",
             tol
         );
+
+        INFO("Comparing NeoFOAM and OpenFOAM moment output files");
         compareDataFiles(
             "postProcessing/neoForces/0/moment.dat",
             "postProcessing/ofForces/0/moment.dat",
             tol
         );
 
+        INFO("Cleaning up output directories");
         fs::remove_all("postProcessing/neoForces");
         fs::remove_all("postProcessing/ofForces");
     }
@@ -180,51 +187,58 @@ TEST_CASE("Forces - pressure force and moment match OpenFOAM reference")
         fs::remove_all("postProcessing/neoForces");
         fs::remove_all("postProcessing/ofForces");
 
-        auto rt = nf::createAdapterRunTime(runTime, exec);
-        auto& mesh = rt.mesh;
+        {
+            auto rt = nf::createAdapterRunTime(runTime, exec);
+            auto& mesh = rt.mesh;
 
-        auto ofP = randomScalarField(runTime, mesh, "p");
-        ofP.correctBoundaryConditions();
+            auto ofP = randomScalarField(runTime, mesh, "p");
+            ofP.correctBoundaryConditions();
 
-        fvcc::VectorCollection& vc = fvcc::VectorCollection::instance(rt.db, "VectorCollection");
-        nf::constructAndRegister(vc, rt, ofP, false);
+            fvcc::VectorCollection& vc =
+                fvcc::VectorCollection::instance(rt.db, "VectorCollection");
+            nf::constructAndRegister(vc, rt, ofP, false);
 
-        Foam::dictionary dict;
-        dict.add("patches", Foam::wordList {"fixedWalls"});
-        dict.add("pName", Foam::word {"p"});
-        dict.add("rhoInf", Foam::scalar {1.225});
-        dict.add("pRef", Foam::scalar {0.5});
-        dict.add("CofR", Foam::vector(0.1, 0.2, 0.3));
+            Foam::dictionary dict;
+            dict.add("patches", Foam::wordList {"fixedWalls"});
+            dict.add("pName", Foam::word {"p"});
+            dict.add("rhoInf", Foam::scalar {1.225});
+            dict.add("pRef", Foam::scalar {0.5});
+            dict.add("CofR", Foam::vector(0.1, 0.2, 0.3));
 
-        nf::Forces forces("neoForces", runTime, dict);
-        REQUIRE(forces.execute());
-        REQUIRE(forces.write());
+            nf::Forces forces("neoForces", runTime, dict);
+            REQUIRE(forces.execute());
+            REQUIRE(forces.write());
 
-        OfForcesSetup ofSetup(mesh, runTime);
+            OfForcesSetup ofSetup(mesh, runTime);
 
-        Foam::dictionary ofDict;
-        ofDict.add("patches", Foam::wordList {"fixedWalls"});
-        ofDict.add("rho", Foam::word("rhoInf"));
-        ofDict.add("rhoInf", Foam::scalar {1.225});
-        ofDict.add("pRef", Foam::scalar {0.5});
-        ofDict.add("CofR", Foam::vector(0.1, 0.2, 0.3));
+            Foam::dictionary ofDict;
+            ofDict.add("patches", Foam::wordList {"fixedWalls"});
+            ofDict.add("rho", Foam::word("rhoInf"));
+            ofDict.add("rhoInf", Foam::scalar {1.225});
+            ofDict.add("pRef", Foam::scalar {0.5});
+            ofDict.add("CofR", Foam::vector(0.1, 0.2, 0.3));
 
-        Foam::functionObjects::forces ofForces("ofForces", runTime, ofDict);
-        REQUIRE(ofForces.execute());
-        REQUIRE(ofForces.write());
+            Foam::functionObjects::forces ofForces("ofForces", runTime, ofDict);
+            REQUIRE(ofForces.execute());
+            REQUIRE(ofForces.write());
+        }
 
+        INFO("Comparing NeoFOAM and OpenFOAM force output files");
         const double tol = 1e-10;
         compareDataFiles(
             "postProcessing/neoForces/0/force.dat",
             "postProcessing/ofForces/0/force.dat",
             tol
         );
+
+        INFO("Comparing NeoFOAM and OpenFOAM moment output files");
         compareDataFiles(
             "postProcessing/neoForces/0/moment.dat",
             "postProcessing/ofForces/0/moment.dat",
             tol
         );
 
+        INFO("Cleaning up output directories");
         fs::remove_all("postProcessing/neoForces");
         fs::remove_all("postProcessing/ofForces");
     }
@@ -234,51 +248,58 @@ TEST_CASE("Forces - pressure force and moment match OpenFOAM reference")
         fs::remove_all("postProcessing/neoForces");
         fs::remove_all("postProcessing/ofForces");
 
-        auto rt = nf::createAdapterRunTime(runTime, exec);
-        auto& mesh = rt.mesh;
+        {
+            auto rt = nf::createAdapterRunTime(runTime, exec);
+            auto& mesh = rt.mesh;
 
-        auto ofP = randomScalarField(runTime, mesh, "p");
-        ofP.correctBoundaryConditions();
+            auto ofP = randomScalarField(runTime, mesh, "p");
+            ofP.correctBoundaryConditions();
 
-        fvcc::VectorCollection& vc = fvcc::VectorCollection::instance(rt.db, "VectorCollection");
-        nf::constructAndRegister(vc, rt, ofP, false);
+            fvcc::VectorCollection& vc =
+                fvcc::VectorCollection::instance(rt.db, "VectorCollection");
+            nf::constructAndRegister(vc, rt, ofP, false);
 
-        Foam::dictionary dict;
-        dict.add("patches", Foam::wordList {"fixedWalls", "inlet", "outlet"});
-        dict.add("pName", Foam::word {"p"});
-        dict.add("rhoInf", Foam::scalar {1.0});
-        dict.add("pRef", Foam::scalar {0.0});
-        dict.add("CofR", Foam::vector(0, 0, 0));
+            Foam::dictionary dict;
+            dict.add("patches", Foam::wordList {"fixedWalls", "inlet", "outlet"});
+            dict.add("pName", Foam::word {"p"});
+            dict.add("rhoInf", Foam::scalar {1.0});
+            dict.add("pRef", Foam::scalar {0.0});
+            dict.add("CofR", Foam::vector(0, 0, 0));
 
-        nf::Forces forces("neoForces", runTime, dict);
-        REQUIRE(forces.execute());
-        REQUIRE(forces.write());
+            nf::Forces forces("neoForces", runTime, dict);
+            REQUIRE(forces.execute());
+            REQUIRE(forces.write());
 
-        OfForcesSetup ofSetup(mesh, runTime);
+            OfForcesSetup ofSetup(mesh, runTime);
 
-        Foam::dictionary ofDict;
-        ofDict.add("patches", Foam::wordList {"fixedWalls", "inlet", "outlet"});
-        ofDict.add("rho", Foam::word("rhoInf"));
-        ofDict.add("rhoInf", Foam::scalar {1.0});
-        ofDict.add("pRef", Foam::scalar {0.0});
-        ofDict.add("CofR", Foam::vector(0, 0, 0));
+            Foam::dictionary ofDict;
+            ofDict.add("patches", Foam::wordList {"fixedWalls", "inlet", "outlet"});
+            ofDict.add("rho", Foam::word("rhoInf"));
+            ofDict.add("rhoInf", Foam::scalar {1.0});
+            ofDict.add("pRef", Foam::scalar {0.0});
+            ofDict.add("CofR", Foam::vector(0, 0, 0));
 
-        Foam::functionObjects::forces ofForces("ofForces", runTime, ofDict);
-        REQUIRE(ofForces.execute());
-        REQUIRE(ofForces.write());
+            Foam::functionObjects::forces ofForces("ofForces", runTime, ofDict);
+            REQUIRE(ofForces.execute());
+            REQUIRE(ofForces.write());
+        }
 
+        INFO("Comparing NeoFOAM and OpenFOAM force output files");
         const double tol = 1e-10;
         compareDataFiles(
             "postProcessing/neoForces/0/force.dat",
             "postProcessing/ofForces/0/force.dat",
             tol
         );
+
+        INFO("Comparing NeoFOAM and OpenFOAM moment output files");
         compareDataFiles(
             "postProcessing/neoForces/0/moment.dat",
             "postProcessing/ofForces/0/moment.dat",
             tol
         );
 
+        INFO("Cleaning up output directories");
         fs::remove_all("postProcessing/neoForces");
         fs::remove_all("postProcessing/ofForces");
     }
@@ -288,64 +309,71 @@ TEST_CASE("Forces - pressure force and moment match OpenFOAM reference")
         fs::remove_all("postProcessing/neoForces");
         fs::remove_all("postProcessing/ofForces");
 
-        auto rt = nf::createAdapterRunTime(runTime, exec);
-        auto& mesh = rt.mesh;
+        {
+            auto rt = nf::createAdapterRunTime(runTime, exec);
+            auto& mesh = rt.mesh;
 
-        auto ofP = randomScalarField(runTime, mesh, "p");
-        ofP.correctBoundaryConditions();
-        auto ofU = randomVectorField(runTime, mesh, "U");
-        ofU.correctBoundaryConditions();
+            auto ofP = randomScalarField(runTime, mesh, "p");
+            ofP.correctBoundaryConditions();
+            auto ofU = randomVectorField(runTime, mesh, "U");
+            ofU.correctBoundaryConditions();
 
-        fvcc::VectorCollection& vc = fvcc::VectorCollection::instance(rt.db, "VectorCollection");
-        nf::constructAndRegister(vc, rt, ofP, false);
-        nf::constructAndRegister(vc, rt, ofU, false);
+            fvcc::VectorCollection& vc =
+                fvcc::VectorCollection::instance(rt.db, "VectorCollection");
+            nf::constructAndRegister(vc, rt, ofP, false);
+            nf::constructAndRegister(vc, rt, ofU, false);
 
-        // transportProperties with non-zero nu registered in Foam::Time registry
-        Foam::IOdictionary transportProps(Foam::IOobject(
-            "transportProperties",
-            runTime.constant(),
-            mesh,
-            Foam::IOobject::NO_READ,
-            Foam::IOobject::NO_WRITE
-        ));
-        const Foam::scalar nu = 1e-5;
-        transportProps.add("nu", nu);
+            // transportProperties with non-zero nu registered in Foam::Time registry
+            Foam::IOdictionary transportProps(Foam::IOobject(
+                "transportProperties",
+                runTime.constant(),
+                mesh,
+                Foam::IOobject::NO_READ,
+                Foam::IOobject::NO_WRITE
+            ));
+            const Foam::scalar nu = 1e-5;
+            transportProps.add("nu", nu);
 
-        Foam::dictionary dict;
-        dict.add("patches", Foam::wordList {"fixedWalls"});
-        dict.add("pName", Foam::word {"p"});
-        dict.add("rhoInf", Foam::scalar {1.225});
-        dict.add("pRef", Foam::scalar {0.0});
-        dict.add("CofR", Foam::vector(0, 0, 0));
+            Foam::dictionary dict;
+            dict.add("patches", Foam::wordList {"fixedWalls"});
+            dict.add("pName", Foam::word {"p"});
+            dict.add("rhoInf", Foam::scalar {1.225});
+            dict.add("pRef", Foam::scalar {0.0});
+            dict.add("CofR", Foam::vector(0, 0, 0));
 
-        nf::Forces forces("neoForces", runTime, dict);
-        REQUIRE(forces.execute());
-        REQUIRE(forces.write());
+            nf::Forces forces("neoForces", runTime, dict);
+            REQUIRE(forces.execute());
+            REQUIRE(forces.write());
 
-        // OF reference — U is already registered (ofU), pass nu to transportProperties
-        Foam::dictionary ofDict;
-        ofDict.add("patches", Foam::wordList {"fixedWalls"});
-        ofDict.add("rho", Foam::word("rhoInf"));
-        ofDict.add("rhoInf", Foam::scalar {1.225});
-        ofDict.add("pRef", Foam::scalar {0.0});
-        ofDict.add("CofR", Foam::vector(0, 0, 0));
+            // OF reference — U is already registered (ofU), pass nu to transportProperties
+            Foam::dictionary ofDict;
+            ofDict.add("patches", Foam::wordList {"fixedWalls"});
+            ofDict.add("rho", Foam::word("rhoInf"));
+            ofDict.add("rhoInf", Foam::scalar {1.225});
+            ofDict.add("pRef", Foam::scalar {0.0});
+            ofDict.add("CofR", Foam::vector(0, 0, 0));
 
-        Foam::functionObjects::forces ofForces("ofForces", runTime, ofDict);
-        REQUIRE(ofForces.execute());
-        REQUIRE(ofForces.write());
+            Foam::functionObjects::forces ofForces("ofForces", runTime, ofDict);
+            REQUIRE(ofForces.execute());
+            REQUIRE(ofForces.write());
+        }
 
+        INFO("Comparing NeoFOAM and OpenFOAM force output files");
         const double tol = 1e-8;
         compareDataFiles(
             "postProcessing/neoForces/0/force.dat",
             "postProcessing/ofForces/0/force.dat",
             tol
         );
+
+        INFO("Comparing NeoFOAM and OpenFOAM moment output files");
         compareDataFiles(
             "postProcessing/neoForces/0/moment.dat",
             "postProcessing/ofForces/0/moment.dat",
             tol
         );
 
+        INFO("Cleaning up output directories");
         fs::remove_all("postProcessing/neoForces");
         fs::remove_all("postProcessing/ofForces");
     }
@@ -465,64 +493,68 @@ TEST_CASE("ForceCoeffs - normalised coefficients match OpenFOAM reference")
         fs::remove_all("postProcessing/neoForceCoeffs");
         fs::remove_all("postProcessing/ofForceCoeffs");
 
-        auto rt = nf::createAdapterRunTime(runTime, exec);
-        auto& mesh = rt.mesh;
+        {
+            auto rt = nf::createAdapterRunTime(runTime, exec);
+            auto& mesh = rt.mesh;
 
-        auto ofP = randomScalarField(runTime, mesh, "p");
-        ofP.correctBoundaryConditions();
+            auto ofP = randomScalarField(runTime, mesh, "p");
+            ofP.correctBoundaryConditions();
 
-        fvcc::VectorCollection& vc = fvcc::VectorCollection::instance(rt.db, "VectorCollection");
-        nf::constructAndRegister(vc, rt, ofP, false);
+            fvcc::VectorCollection& vc =
+                fvcc::VectorCollection::instance(rt.db, "VectorCollection");
+            nf::constructAndRegister(vc, rt, ofP, false);
 
-        const Foam::scalar rhoRef = 1.225;
-        const Foam::scalar magUInf = 10.0;
-        const Foam::scalar lRef = 0.5;
-        const Foam::scalar Aref = 0.25;
-        const Foam::scalar pRef = 0.0;
-        const Foam::vector cofR = Foam::vector::zero;
+            const Foam::scalar rhoRef = 1.225;
+            const Foam::scalar magUInf = 10.0;
+            const Foam::scalar lRef = 0.5;
+            const Foam::scalar Aref = 0.25;
+            const Foam::scalar pRef = 0.0;
+            const Foam::vector cofR = Foam::vector::zero;
 
-        // ── NeoFOAM ForceCoeffs ──────────────────────────────────────────────
-        Foam::dictionary dict;
-        dict.add("patches", Foam::wordList {"fixedWalls"});
-        dict.add("pName", Foam::word {"p"});
-        dict.add("rhoInf", rhoRef);
-        dict.add("pRef", pRef);
-        dict.add("magUInf", magUInf);
-        dict.add("lRef", lRef);
-        dict.add("Aref", Aref);
-        dict.add("CofR", cofR);
+            // ── NeoFOAM ForceCoeffs ──────────────────────────────────────────────
+            Foam::dictionary dict;
+            dict.add("patches", Foam::wordList {"fixedWalls"});
+            dict.add("pName", Foam::word {"p"});
+            dict.add("rhoInf", rhoRef);
+            dict.add("pRef", pRef);
+            dict.add("magUInf", magUInf);
+            dict.add("lRef", lRef);
+            dict.add("Aref", Aref);
+            dict.add("CofR", cofR);
 
-        dict.add("dragDir", Foam::vector(1, 0, 0));
-        dict.add("liftDir", Foam::vector(0, 0, 1));
-        dict.add("pitchAxis", Foam::vector(0, 1, 0));
+            dict.add("dragDir", Foam::vector(1, 0, 0));
+            dict.add("liftDir", Foam::vector(0, 0, 1));
+            dict.add("pitchAxis", Foam::vector(0, 1, 0));
 
-        nf::ForceCoeffs fc("neoForceCoeffs", runTime, dict);
-        REQUIRE(fc.execute());
-        REQUIRE(fc.write());
+            nf::ForceCoeffs fc("neoForceCoeffs", runTime, dict);
+            REQUIRE(fc.execute());
+            REQUIRE(fc.write());
 
-        // ── OF forceCoeffs reference ─────────────────────────────────────────
-        OfForcesSetup ofSetup(mesh, runTime);
+            // ── OF forceCoeffs reference ─────────────────────────────────────────
+            OfForcesSetup ofSetup(mesh, runTime);
 
-        Foam::dictionary ofDict;
-        ofDict.add("patches", Foam::wordList {"fixedWalls"});
-        ofDict.add("rho", Foam::word("rhoInf"));
-        ofDict.add("rhoInf", rhoRef);
-        ofDict.add("pRef", pRef);
-        ofDict.add("magUInf", magUInf);
-        ofDict.add("lRef", lRef);
-        ofDict.add("Aref", Aref);
-        ofDict.add("CofR", cofR);
-        ofDict.add("dragDir", Foam::vector(1, 0, 0));
-        ofDict.add("liftDir", Foam::vector(0, 0, 1));
-        ofDict.add("pitchAxis", Foam::vector(0, 1, 0));
+            Foam::dictionary ofDict;
+            ofDict.add("patches", Foam::wordList {"fixedWalls"});
+            ofDict.add("rho", Foam::word("rhoInf"));
+            ofDict.add("rhoInf", rhoRef);
+            ofDict.add("pRef", pRef);
+            ofDict.add("magUInf", magUInf);
+            ofDict.add("lRef", lRef);
+            ofDict.add("Aref", Aref);
+            ofDict.add("CofR", cofR);
+            ofDict.add("dragDir", Foam::vector(1, 0, 0));
+            ofDict.add("liftDir", Foam::vector(0, 0, 1));
+            ofDict.add("pitchAxis", Foam::vector(0, 1, 0));
 
-        Foam::functionObjects::forceCoeffs ofFc("ofForceCoeffs", runTime, ofDict);
-        REQUIRE(ofFc.execute());
-        REQUIRE(ofFc.write());
+            Foam::functionObjects::forceCoeffs ofFc("ofForceCoeffs", runTime, ofDict);
+            REQUIRE(ofFc.execute());
+            REQUIRE(ofFc.write());
+        }
 
         // ── Compare coefficient.dat ──────────────────────────────────────────
         // Both NeoFOAM and OF write 12 coefficient columns in alphabetical order:
         // Cd Cd(f) Cd(r) Cl Cl(f) Cl(r) CmPitch CmRoll CmYaw Cs Cs(f) Cs(r)
+        INFO("Comparing NeoFOAM and OpenFOAM coefficient output files");
         const double tol = 1e-10;
         compareDataFiles(
             "postProcessing/neoForceCoeffs/0/coefficient.dat",
@@ -530,6 +562,7 @@ TEST_CASE("ForceCoeffs - normalised coefficients match OpenFOAM reference")
             tol
         );
 
+        INFO("Cleaning up output directories");
         fs::remove_all("postProcessing/neoForceCoeffs");
         fs::remove_all("postProcessing/ofForceCoeffs");
     }
@@ -539,69 +572,73 @@ TEST_CASE("ForceCoeffs - normalised coefficients match OpenFOAM reference")
         fs::remove_all("postProcessing/neoForceCoeffs");
         fs::remove_all("postProcessing/ofForceCoeffs");
 
-        auto rt = nf::createAdapterRunTime(runTime, exec);
-        auto& mesh = rt.mesh;
+        {
+            auto rt = nf::createAdapterRunTime(runTime, exec);
+            auto& mesh = rt.mesh;
 
-        auto ofP = randomScalarField(runTime, mesh, "p");
-        ofP.correctBoundaryConditions();
-        auto ofU = randomVectorField(runTime, mesh, "U");
-        ofU.correctBoundaryConditions();
+            auto ofP = randomScalarField(runTime, mesh, "p");
+            ofP.correctBoundaryConditions();
+            auto ofU = randomVectorField(runTime, mesh, "U");
+            ofU.correctBoundaryConditions();
 
-        fvcc::VectorCollection& vc = fvcc::VectorCollection::instance(rt.db, "VectorCollection");
-        nf::constructAndRegister(vc, rt, ofP, false);
-        nf::constructAndRegister(vc, rt, ofU, false);
+            fvcc::VectorCollection& vc =
+                fvcc::VectorCollection::instance(rt.db, "VectorCollection");
+            nf::constructAndRegister(vc, rt, ofP, false);
+            nf::constructAndRegister(vc, rt, ofU, false);
 
-        Foam::IOdictionary transportProps(Foam::IOobject(
-            "transportProperties",
-            runTime.constant(),
-            mesh,
-            Foam::IOobject::NO_READ,
-            Foam::IOobject::NO_WRITE
-        ));
-        const Foam::scalar nu = 1e-5;
-        transportProps.add("nu", nu);
+            Foam::IOdictionary transportProps(Foam::IOobject(
+                "transportProperties",
+                runTime.constant(),
+                mesh,
+                Foam::IOobject::NO_READ,
+                Foam::IOobject::NO_WRITE
+            ));
+            const Foam::scalar nu = 1e-5;
+            transportProps.add("nu", nu);
 
-        const Foam::scalar rhoRef = 1.225;
-        const Foam::scalar magUInf = 10.0;
-        const Foam::scalar lRef = 0.5;
-        const Foam::scalar Aref = 0.25;
-        const Foam::scalar pRef = 0.0;
-        const Foam::vector cofR = Foam::vector::zero;
+            const Foam::scalar rhoRef = 1.225;
+            const Foam::scalar magUInf = 10.0;
+            const Foam::scalar lRef = 0.5;
+            const Foam::scalar Aref = 0.25;
+            const Foam::scalar pRef = 0.0;
+            const Foam::vector cofR = Foam::vector::zero;
 
-        Foam::dictionary dict;
-        dict.add("patches", Foam::wordList {"fixedWalls"});
-        dict.add("pName", Foam::word {"p"});
-        dict.add("rhoInf", rhoRef);
-        dict.add("pRef", pRef);
-        dict.add("magUInf", magUInf);
-        dict.add("lRef", lRef);
-        dict.add("Aref", Aref);
-        dict.add("CofR", cofR);
-        dict.add("dragDir", Foam::vector(1, 0, 0));
-        dict.add("liftDir", Foam::vector(0, 0, 1));
-        dict.add("pitchAxis", Foam::vector(0, 1, 0));
+            Foam::dictionary dict;
+            dict.add("patches", Foam::wordList {"fixedWalls"});
+            dict.add("pName", Foam::word {"p"});
+            dict.add("rhoInf", rhoRef);
+            dict.add("pRef", pRef);
+            dict.add("magUInf", magUInf);
+            dict.add("lRef", lRef);
+            dict.add("Aref", Aref);
+            dict.add("CofR", cofR);
+            dict.add("dragDir", Foam::vector(1, 0, 0));
+            dict.add("liftDir", Foam::vector(0, 0, 1));
+            dict.add("pitchAxis", Foam::vector(0, 1, 0));
 
-        nf::ForceCoeffs fc("neoForceCoeffs", runTime, dict);
-        REQUIRE(fc.execute());
-        REQUIRE(fc.write());
+            nf::ForceCoeffs fc("neoForceCoeffs", runTime, dict);
+            REQUIRE(fc.execute());
+            REQUIRE(fc.write());
 
-        Foam::dictionary ofDict;
-        ofDict.add("patches", Foam::wordList {"fixedWalls"});
-        ofDict.add("rho", Foam::word("rhoInf"));
-        ofDict.add("rhoInf", rhoRef);
-        ofDict.add("pRef", pRef);
-        ofDict.add("magUInf", magUInf);
-        ofDict.add("lRef", lRef);
-        ofDict.add("Aref", Aref);
-        ofDict.add("CofR", cofR);
-        ofDict.add("dragDir", Foam::vector(1, 0, 0));
-        ofDict.add("liftDir", Foam::vector(0, 0, 1));
-        ofDict.add("pitchAxis", Foam::vector(0, 1, 0));
+            Foam::dictionary ofDict;
+            ofDict.add("patches", Foam::wordList {"fixedWalls"});
+            ofDict.add("rho", Foam::word("rhoInf"));
+            ofDict.add("rhoInf", rhoRef);
+            ofDict.add("pRef", pRef);
+            ofDict.add("magUInf", magUInf);
+            ofDict.add("lRef", lRef);
+            ofDict.add("Aref", Aref);
+            ofDict.add("CofR", cofR);
+            ofDict.add("dragDir", Foam::vector(1, 0, 0));
+            ofDict.add("liftDir", Foam::vector(0, 0, 1));
+            ofDict.add("pitchAxis", Foam::vector(0, 1, 0));
 
-        Foam::functionObjects::forceCoeffs ofFc("ofForceCoeffs", runTime, ofDict);
-        REQUIRE(ofFc.execute());
-        REQUIRE(ofFc.write());
+            Foam::functionObjects::forceCoeffs ofFc("ofForceCoeffs", runTime, ofDict);
+            REQUIRE(ofFc.execute());
+            REQUIRE(ofFc.write());
+        }
 
+        INFO("Comparing NeoFOAM and OpenFOAM coefficient output files");
         const double tol = 1e-8;
         compareDataFiles(
             "postProcessing/neoForceCoeffs/0/coefficient.dat",
@@ -609,6 +646,7 @@ TEST_CASE("ForceCoeffs - normalised coefficients match OpenFOAM reference")
             tol
         );
 
+        INFO("Cleaning up output directories");
         fs::remove_all("postProcessing/neoForceCoeffs");
         fs::remove_all("postProcessing/ofForceCoeffs");
     }

--- a/test/test_forceCoeffs.cpp
+++ b/test/test_forceCoeffs.cpp
@@ -110,8 +110,8 @@ TEST_CASE("Forces - pressure force and moment match OpenFOAM reference")
 
     SECTION("uniform pressure, fixedWalls" + execName)
     {
-        fs::remove_all("postProcessing/neoForces");
-        fs::remove_all("postProcessing/ofForces");
+        REQUIRE_NOTHROW(fs::remove_all("postProcessing/neoForces"));
+        REQUIRE_NOTHROW(fs::remove_all("postProcessing/ofForces"));
 
         {
             auto rt = nf::createAdapterRunTime(runTime, exec);
@@ -178,14 +178,14 @@ TEST_CASE("Forces - pressure force and moment match OpenFOAM reference")
         );
 
         INFO("Cleaning up output directories");
-        fs::remove_all("postProcessing/neoForces");
-        fs::remove_all("postProcessing/ofForces");
+        CHECK_NOTHROW(fs::remove_all("postProcessing/neoForces"));
+        CHECK_NOTHROW(fs::remove_all("postProcessing/ofForces"));
     }
 
     SECTION("random pressure field, fixedWalls" + execName)
     {
-        fs::remove_all("postProcessing/neoForces");
-        fs::remove_all("postProcessing/ofForces");
+        REQUIRE_NOTHROW(fs::remove_all("postProcessing/neoForces"));
+        REQUIRE_NOTHROW(fs::remove_all("postProcessing/ofForces"));
 
         {
             auto rt = nf::createAdapterRunTime(runTime, exec);
@@ -239,14 +239,14 @@ TEST_CASE("Forces - pressure force and moment match OpenFOAM reference")
         );
 
         INFO("Cleaning up output directories");
-        fs::remove_all("postProcessing/neoForces");
-        fs::remove_all("postProcessing/ofForces");
+        CHECK_NOTHROW(fs::remove_all("postProcessing/neoForces"));
+        CHECK_NOTHROW(fs::remove_all("postProcessing/ofForces"));
     }
 
     SECTION("multiple patches: fixedWalls + inlet + outlet" + execName)
     {
-        fs::remove_all("postProcessing/neoForces");
-        fs::remove_all("postProcessing/ofForces");
+        REQUIRE_NOTHROW(fs::remove_all("postProcessing/neoForces"));
+        REQUIRE_NOTHROW(fs::remove_all("postProcessing/ofForces"));
 
         {
             auto rt = nf::createAdapterRunTime(runTime, exec);
@@ -300,14 +300,14 @@ TEST_CASE("Forces - pressure force and moment match OpenFOAM reference")
         );
 
         INFO("Cleaning up output directories");
-        fs::remove_all("postProcessing/neoForces");
-        fs::remove_all("postProcessing/ofForces");
+        CHECK_NOTHROW(fs::remove_all("postProcessing/neoForces"));
+        CHECK_NOTHROW(fs::remove_all("postProcessing/ofForces"));
     }
 
     SECTION("random U + non-zero viscous forces, fixedWalls" + execName)
     {
-        fs::remove_all("postProcessing/neoForces");
-        fs::remove_all("postProcessing/ofForces");
+        REQUIRE_NOTHROW(fs::remove_all("postProcessing/neoForces"));
+        REQUIRE_NOTHROW(fs::remove_all("postProcessing/ofForces"));
 
         {
             auto rt = nf::createAdapterRunTime(runTime, exec);
@@ -374,16 +374,16 @@ TEST_CASE("Forces - pressure force and moment match OpenFOAM reference")
         );
 
         INFO("Cleaning up output directories");
-        fs::remove_all("postProcessing/neoForces");
-        fs::remove_all("postProcessing/ofForces");
+        CHECK_NOTHROW(fs::remove_all("postProcessing/neoForces"));
+        CHECK_NOTHROW(fs::remove_all("postProcessing/ofForces"));
     }
 
     SECTION("random U + turbulent nuEff (nu + nut), fixedWalls" + execName)
     {
         // TODO: This test assumes nuEff in OpenFOAM is calculated as nu + nut on each patch face,
         // we never test if the NeoFOAM nuEff is actually equalt to OpenFOAMs nuEff
-        fs::remove_all("postProcessing/neoForces");
-        fs::remove_all("postProcessing/ofForces");
+        REQUIRE_NOTHROW(fs::remove_all("postProcessing/neoForces"));
+        REQUIRE_NOTHROW(fs::remove_all("postProcessing/ofForces"));
 
         const Foam::scalar nu = 1e-5;
         const Foam::scalar nutConst = 5e-4;
@@ -475,8 +475,8 @@ TEST_CASE("Forces - pressure force and moment match OpenFOAM reference")
             tol
         );
 
-        fs::remove_all("postProcessing/neoForces");
-        fs::remove_all("postProcessing/ofForces");
+        CHECK_NOTHROW(fs::remove_all("postProcessing/neoForces"));
+        CHECK_NOTHROW(fs::remove_all("postProcessing/ofForces"));
     }
 }
 
@@ -490,8 +490,8 @@ TEST_CASE("ForceCoeffs - normalised coefficients match OpenFOAM reference")
 
     SECTION("random pressure, all coefficients" + execName)
     {
-        fs::remove_all("postProcessing/neoForceCoeffs");
-        fs::remove_all("postProcessing/ofForceCoeffs");
+        REQUIRE_NOTHROW(fs::remove_all("postProcessing/neoForceCoeffs"));
+        REQUIRE_NOTHROW(fs::remove_all("postProcessing/ofForceCoeffs"));
 
         {
             auto rt = nf::createAdapterRunTime(runTime, exec);
@@ -563,14 +563,14 @@ TEST_CASE("ForceCoeffs - normalised coefficients match OpenFOAM reference")
         );
 
         INFO("Cleaning up output directories");
-        fs::remove_all("postProcessing/neoForceCoeffs");
-        fs::remove_all("postProcessing/ofForceCoeffs");
+        CHECK_NOTHROW(fs::remove_all("postProcessing/neoForceCoeffs"));
+        CHECK_NOTHROW(fs::remove_all("postProcessing/ofForceCoeffs"));
     }
 
     SECTION("random U + non-zero viscous forces, all coefficients" + execName)
     {
-        fs::remove_all("postProcessing/neoForceCoeffs");
-        fs::remove_all("postProcessing/ofForceCoeffs");
+        REQUIRE_NOTHROW(fs::remove_all("postProcessing/neoForceCoeffs"));
+        REQUIRE_NOTHROW(fs::remove_all("postProcessing/ofForceCoeffs"));
 
         {
             auto rt = nf::createAdapterRunTime(runTime, exec);
@@ -647,8 +647,8 @@ TEST_CASE("ForceCoeffs - normalised coefficients match OpenFOAM reference")
         );
 
         INFO("Cleaning up output directories");
-        fs::remove_all("postProcessing/neoForceCoeffs");
-        fs::remove_all("postProcessing/ofForceCoeffs");
+        CHECK_NOTHROW(fs::remove_all("postProcessing/neoForceCoeffs"));
+        CHECK_NOTHROW(fs::remove_all("postProcessing/ofForceCoeffs"));
     }
 }
 


### PR DESCRIPTION
## What is it about
Fix the NFS (Network File System) errors when attempting to remove output directories in the unit test of force coefficients.

## Outcome
Restructure the unit test so that
- No more NFS errors 
- Make it obvious whether the failure occurred during comparison or cleanup