### PR TITLE
Improve configuration of NeoN with different label size exposed by OpenFOAM

### DIFF
--- a/cmake/OpenFOAM.cmake
+++ b/cmake/OpenFOAM.cmake
@@ -58,9 +58,23 @@ target_include_directories(
 target_compile_definitions(OpenFOAM INTERFACE WM_LABEL_SIZE=$ENV{WM_LABEL_SIZE} NoRepository
                                               WM_$ENV{WM_PRECISION_OPTION} OPENFOAM=$ENV{FOAM_API})
 
-# Foam exposes WM_LABEL_SIZE (32/64); propagate to NeoN's label width
+# OpenFOAM exposes its label width via WM_LABEL_SIZE (32/64). Configure NeoN's
+# corresponding CMake option before it is added as a subdirectory so that NeoN
+# can set its own public compile definitions (NeoN_DP_LABEL) consistently.
 if($ENV{WM_LABEL_SIZE} EQUAL 64)
-  target_compile_definitions(NeoN PUBLIC NeoN_DP_LABEL)
+    set(
+        NeoN_DEFINE_DP_LABEL
+        ON
+        CACHE BOOL
+        "Use 64-bit labels to match OpenFOAM"
+        FORCE)
+else()
+    set(
+        NeoN_DEFINE_DP_LABEL
+        OFF
+        CACHE BOOL
+        "Use 32-bit labels to match OpenFOAM"
+        FORCE)
 endif()
 
 importoflibrary(OpenFOAM)

--- a/cmake/OpenFOAM.cmake
+++ b/cmake/OpenFOAM.cmake
@@ -58,23 +58,17 @@ target_include_directories(
 target_compile_definitions(OpenFOAM INTERFACE WM_LABEL_SIZE=$ENV{WM_LABEL_SIZE} NoRepository
                                               WM_$ENV{WM_PRECISION_OPTION} OPENFOAM=$ENV{FOAM_API})
 
-# OpenFOAM exposes its label width via WM_LABEL_SIZE (32/64). Configure NeoN's
-# corresponding CMake option before it is added as a subdirectory so that NeoN
-# can set its own public compile definitions (NeoN_DP_LABEL) consistently.
+# OpenFOAM exposes its label width via WM_LABEL_SIZE (32/64). Configure NeoN's corresponding CMake
+# option before it is added as a subdirectory so that NeoN can set its own public compile
+# definitions (NeoN_DP_LABEL) consistently.
 if($ENV{WM_LABEL_SIZE} EQUAL 64)
-    set(
-        NeoN_DEFINE_DP_LABEL
-        ON
-        CACHE BOOL
-        "Use 64-bit labels to match OpenFOAM"
-        FORCE)
+  set(NeoN_DEFINE_DP_LABEL
+      ON
+      CACHE BOOL "Use 64-bit labels to match OpenFOAM" FORCE)
 else()
-    set(
-        NeoN_DEFINE_DP_LABEL
-        OFF
-        CACHE BOOL
-        "Use 32-bit labels to match OpenFOAM"
-        FORCE)
+  set(NeoN_DEFINE_DP_LABEL
+      OFF
+      CACHE BOOL "Use 32-bit labels to match OpenFOAM" FORCE)
 endif()
 
 importoflibrary(OpenFOAM)

--- a/src/turbulenceModels/kEpsilon.cpp
+++ b/src/turbulenceModels/kEpsilon.cpp
@@ -57,9 +57,9 @@ void kernelComputeSources(
         exec,
         {0, static_cast<localIdx>(kVec.size())},
         NEON_LAMBDA(const localIdx i) {
-            const scalar k_i = Kokkos::max(kV[i], scalar(0));
-            const scalar eps_i = Kokkos::max(epsV[i], rootVSmall);
-            const scalar nut_i = nutV[i];
+            const scalar kI = Kokkos::max(kV[i], scalar(0));
+            const scalar epsI = Kokkos::max(epsV[i], rootVSmall);
+            const scalar nutI = nutV[i];
 
             // GbyNu0 = ∇U && devTwoSymm(∇U)
             //   = ∇U·∇U + ∇U·∇Uᵀ - (2/3)(div U)²
@@ -76,24 +76,24 @@ void kernelComputeSources(
                 }
             }
             const scalar divU = g(0, 0) + g(1, 1) + g(2, 2);
-            const scalar S2_i = normSq + dotTrans;
-            const scalar GbyNu0_i = S2_i - (scalar(2) / scalar(3)) * divU * divU;
+            const scalar s2I = normSq + dotTrans;
+            const scalar gbyNu0I = s2I - (scalar(2) / scalar(3)) * divU * divU;
 
             // Production: G = ν_t · GbyNu0
-            const scalar G_i = nut_i * GbyNu0_i;
+            const scalar gI = nutI * gbyNu0I;
 
             // k equation:
             //   source: +G
             //   implicit destruction (sp): ε/k     → spK = ε/k
-            pkV[i] = G_i;
-            spKV[i] = eps_i / Kokkos::max(k_i, rootVSmall);
+            pkV[i] = gI;
+            spKV[i] = epsI / Kokkos::max(kI, rootVSmall);
 
             // ε equation:
             //   source: +C1 · Cμ · k · GbyNu0  (since C1·G·ε/k = C1·Cμ·k·GbyNu0
             //                                    using ν_t = Cμ·k²/ε)
             //   implicit destruction (sp): C2 · ε/k → spEps = C2 · ε/k
-            epsSV[i] = C1 * cmu * k_i * GbyNu0_i;
-            spEpsV[i] = C2 * eps_i / Kokkos::max(k_i, rootVSmall);
+            epsSV[i] = C1 * cmu * kI * gbyNu0I;
+            spEpsV[i] = C2 * epsI / Kokkos::max(kI, rootVSmall);
         },
         "kEpsilon::computeSources"
     );
@@ -117,9 +117,9 @@ void kernelCorrectNutInternal(
         exec,
         {0, static_cast<localIdx>(kVec.size())},
         NEON_LAMBDA(const localIdx i) {
-            const scalar k_i = Kokkos::max(kV[i], scalar(0));
-            const scalar eps_i = Kokkos::max(epsV[i], rootVSmall);
-            nutV_[i] = cmu * k_i * k_i / eps_i;
+            const scalar kI = Kokkos::max(kV[i], scalar(0));
+            const scalar epsI = Kokkos::max(epsV[i], rootVSmall);
+            nutV_[i] = cmu * kI * kI / epsI;
         },
         "kEpsilon::correctNutInternal"
     );
@@ -466,8 +466,8 @@ void KEpsilon::correct(
             exec_,
             {0, static_cast<localIdx>(epsilon.internalVector().size())},
             NEON_LAMBDA(const localIdx i) {
-                const scalar k_i = Kokkos::max(kV[i], rootVSmall);
-                spKView[i] = epsV[i] / k_i;
+                const scalar kI = Kokkos::max(kV[i], rootVSmall);
+                spKView[i] = epsV[i] / kI;
             },
             "kEpsilon::updateSpKFromNewEpsilon"
         );

--- a/src/turbulenceModels/kOmegaSSTKernels.cpp
+++ b/src/turbulenceModels/kOmegaSSTKernels.cpp
@@ -262,46 +262,46 @@ void kernelComputeF1AndSources(
         exec,
         {0, static_cast<localIdx>(kVec.size())},
         NEON_LAMBDA(const localIdx i) {
-            const scalar k_i = kV[i];
-            const scalar omega_i = omegaV[i];
-            const scalar nu_i = nuV[i];
-            const scalar y_i = Kokkos::max(wallDistV[i], rootVSmall);
-            const scalar y2_i = y_i * y_i;
+            const scalar kI = kV[i];
+            const scalar omegaI = omegaV[i];
+            const scalar nuI = nuV[i];
+            const scalar yI = Kokkos::max(wallDistV[i], rootVSmall);
+            const scalar y2I = yI * yI;
 
-            const scalar omegaSafe = Kokkos::max(omega_i, omegaMin);
-            const scalar kSafe = Kokkos::max(k_i, scalar(0));
+            const scalar omegaSafe = Kokkos::max(omegaI, omegaMin);
+            const scalar kSafe = Kokkos::max(kI, scalar(0));
 
             const scalar dotGradKOmega = gradKV[i][0] * gradOmegaV[i][0]
                                        + gradKV[i][1] * gradOmegaV[i][1]
                                        + gradKV[i][2] * gradOmegaV[i][2];
 
-            const scalar CDkOmegaPlus =
+            const scalar cDkOmegaPlus =
                 Kokkos::max(scalar(2) * alphaOmega2 * dotGradKOmega / omegaSafe, scalar(1e-10));
 
-            const scalar sqrtK = Kokkos::sqrt(Kokkos::max(k_i, scalar(0)));
+            const scalar sqrtK = Kokkos::sqrt(Kokkos::max(kI, scalar(0)));
 
             const scalar arg1 = Kokkos::min(
                 Kokkos::min(
                     Kokkos::max(
-                        sqrtK / (betaStar * omegaSafe * y_i),
-                        scalar(500) * nu_i / (y2_i * omegaSafe)
+                        sqrtK / (betaStar * omegaSafe * yI),
+                        scalar(500) * nuI / (y2I * omegaSafe)
                     ),
-                    scalar(4) * alphaOmega2 * k_i / (CDkOmegaPlus * y2_i)
+                    scalar(4) * alphaOmega2 * kI / (cDkOmegaPlus * y2I)
                 ),
                 scalar(10)
             );
             const scalar arg14 = arg1 * arg1 * arg1 * arg1;
             f1V[i] = Kokkos::tanh(arg14);
-            const scalar F1_i = f1V[i];
+            const scalar f1I = f1V[i];
 
             const scalar arg2 = Kokkos::min(
                 Kokkos::max(
-                    scalar(2) * sqrtK / (betaStar * omegaSafe * y_i),
-                    scalar(500) * nu_i / (y2_i * omegaSafe)
+                    scalar(2) * sqrtK / (betaStar * omegaSafe * yI),
+                    scalar(500) * nuI / (y2I * omegaSafe)
                 ),
                 scalar(100)
             );
-            const scalar F2_i = Kokkos::tanh(arg2 * arg2);
+            const scalar f2I = Kokkos::tanh(arg2 * arg2);
 
             const Tensor& g = gradUV[i];
 
@@ -317,30 +317,30 @@ void kernelComputeF1AndSources(
             }
             const scalar divU = g(0, 0) + g(1, 1) + g(2, 2);
 
-            const scalar S2_i = normSq + dotTrans;
-            const scalar GbyNu0_i = S2_i - (scalar(2) / scalar(3)) * divU * divU;
+            const scalar s2I = normSq + dotTrans;
+            const scalar gbyNu0I = s2I - (scalar(2) / scalar(3)) * divU * divU;
 
-            const scalar sqrtS2 = Kokkos::sqrt(Kokkos::max(S2_i, scalar(0)));
-            const scalar nut_i = Kokkos::min(Kokkos::max(nutV[i], scalar(0)), nutMax);
+            const scalar sqrtS2 = Kokkos::sqrt(Kokkos::max(s2I, scalar(0)));
+            const scalar nutI = Kokkos::min(Kokkos::max(nutV[i], scalar(0)), nutMax);
 
-            const scalar gamma_i = F1_i * (gamma1 - gamma2) + gamma2;
-            const scalar beta_i = F1_i * (beta1 - beta2) + beta2;
+            const scalar gammaI = f1I * (gamma1 - gamma2) + gamma2;
+            const scalar betaI = f1I * (beta1 - beta2) + beta2;
 
-            const scalar G_i = nut_i * GbyNu0_i;
-            pkV[i] = Kokkos::min(G_i, c1 * betaStar * kSafe * omegaSafe);
+            const scalar gI = nutI * gbyNu0I;
+            pkV[i] = Kokkos::min(gI, c1 * betaStar * kSafe * omegaSafe);
 
             spKV[i] = betaStar * omegaSafe;
 
-            const scalar GbyNuBound_i = Kokkos::min(
-                GbyNu0_i,
-                (c1 / a1) * betaStar * omegaSafe * Kokkos::max(a1 * omegaSafe, b1 * F2_i * sqrtS2)
+            const scalar gbyNuBoundI = Kokkos::min(
+                gbyNu0I,
+                (c1 / a1) * betaStar * omegaSafe * Kokkos::max(a1 * omegaSafe, b1 * f2I * sqrtS2)
             );
-            omegaSourceV[i] = gamma_i * GbyNuBound_i;
+            omegaSourceV[i] = gammaI * gbyNuBoundI;
 
-            spOmegaV[i] = beta_i * omegaSafe;
+            spOmegaV[i] = betaI * omegaSafe;
 
             const scalar CDkOmegaActual = scalar(2) * alphaOmega2 * dotGradKOmega / omegaSafe;
-            const scalar crossSource = (scalar(1) - F1_i) * CDkOmegaActual;
+            const scalar crossSource = (scalar(1) - f1I) * CDkOmegaActual;
 
             omegaSourceV[i] += Kokkos::max(crossSource, scalar(0));
             spOmegaV[i] += Kokkos::max(-crossSource / omegaSafe, scalar(0));
@@ -373,24 +373,24 @@ void kernelCorrectNutInternal(
         exec,
         {0, static_cast<localIdx>(kVec.size())},
         NEON_LAMBDA(const localIdx i) {
-            const scalar k_i = kV[i];
-            const scalar omega_i = omegaV[i];
-            const scalar nu_i = nuV[i];
-            const scalar y_i = Kokkos::max(wallDistV[i], rootVSmall);
-            const scalar y2_i = y_i * y_i;
+            const scalar kI = kV[i];
+            const scalar omegaI = omegaV[i];
+            const scalar nuI = nuV[i];
+            const scalar yI = Kokkos::max(wallDistV[i], rootVSmall);
+            const scalar y2I = yI * yI;
 
-            const scalar omegaSafe = Kokkos::max(omega_i, omegaMin);
-            const scalar kSafe = Kokkos::max(k_i, scalar(0));
+            const scalar omegaSafe = Kokkos::max(omegaI, omegaMin);
+            const scalar kSafe = Kokkos::max(kI, scalar(0));
 
             const scalar sqrtK = Kokkos::sqrt(kSafe);
             const scalar arg2 = Kokkos::min(
                 Kokkos::max(
-                    scalar(2) * sqrtK / (betaStar * omegaSafe * y_i),
-                    scalar(500) * nu_i / (y2_i * omegaSafe)
+                    scalar(2) * sqrtK / (betaStar * omegaSafe * yI),
+                    scalar(500) * nuI / (y2I * omegaSafe)
                 ),
                 scalar(100)
             );
-            const scalar F2_i = Kokkos::tanh(arg2 * arg2);
+            const scalar f2I = Kokkos::tanh(arg2 * arg2);
 
             const Tensor& g = gradUV[i];
             scalar normSq = scalar(0);
@@ -403,10 +403,10 @@ void kernelCorrectNutInternal(
                     dotTrans += g(r, c) * g(c, r);
                 }
             }
-            const scalar S2_i = normSq + dotTrans;
-            const scalar sqrtS2 = Kokkos::sqrt(Kokkos::max(S2_i, scalar(0)));
+            const scalar s2I = normSq + dotTrans;
+            const scalar sqrtS2 = Kokkos::sqrt(Kokkos::max(s2I, scalar(0)));
 
-            const scalar nutRaw = a1 * kSafe / Kokkos::max(a1 * omegaSafe, b1 * F2_i * sqrtS2);
+            const scalar nutRaw = a1 * kSafe / Kokkos::max(a1 * omegaSafe, b1 * f2I * sqrtS2);
             nutV_[i] = Kokkos::min(nutRaw, nutMax);
         },
         "kOmegaSST::correctNutInternal"

--- a/test/turbulence/kEpsilon.cpp
+++ b/test/turbulence/kEpsilon.cpp
@@ -35,11 +35,11 @@ extern Foam::fvMesh* meshPtr;
 Foam::volScalarField
 computeOfNutKEps(const Foam::volScalarField& k, const Foam::volScalarField& epsilon)
 {
-    const Foam::scalar Cmu = 0.09;
+    const Foam::scalar cmu = 0.09;
     const Foam::scalar rootVSmall = 1e-30;
     return Foam::volScalarField(
         "ofNutKEps",
-        Cmu * Foam::sqr(Foam::max(k, Foam::dimensionedScalar("0", k.dimensions(), 0)))
+        cmu * Foam::sqr(Foam::max(k, Foam::dimensionedScalar("0", k.dimensions(), 0)))
             / Foam::max(
                 epsilon,
                 Foam::dimensionedScalar("rootVSmall", epsilon.dimensions(), rootVSmall)
@@ -133,13 +133,13 @@ TEST_CASE("kEpsilon: computeSources matches OpenFOAM")
     );
 
     // epsilonSource = C1 * Cmu * k * GbyNu0  (= C1 * G * epsilon/k, since nut=Cmu*k²/eps)
-    const Foam::scalar Cmu = 0.09, C1 = 1.44, C2 = 1.92;
-    Foam::volScalarField ofEpsSource("ofEpsSource", C1 * Cmu * ofK * ofGbyNu0);
+    const Foam::scalar cmu = 0.09, c1 = 1.44, c2 = 1.92;
+    Foam::volScalarField ofEpsSource("ofEpsSource", c1 * cmu * ofK * ofGbyNu0);
 
     // spEpsilon = C2 * epsilon/k
     Foam::volScalarField ofSpEps(
         "ofSpEps",
-        C2 * ofEps
+        c2 * ofEps
             / Foam::max(ofK, Foam::dimensionedScalar("rootVSmall", ofK.dimensions(), rootVSmall))
     );
 

--- a/test/turbulence/kOmegaSST.cpp
+++ b/test/turbulence/kOmegaSST.cpp
@@ -48,7 +48,7 @@ Foam::volScalarField computeOfF1(
     auto tgradOmega = fvc::grad(omega);
 
     // CDkOmega clamped to > 0 for F1 stability
-    Foam::tmp<Foam::volScalarField> CDkOmegaPlus = Foam::max(
+    Foam::tmp<Foam::volScalarField> cDkOmegaPlus = Foam::max(
         Foam::tmp<Foam::volScalarField>(new Foam::volScalarField(
             "CDkOmegaPlus",
             2 * alphaOmega2 * (tgradK() & tgradOmega()) / omega
@@ -61,7 +61,7 @@ Foam::volScalarField computeOfF1(
     auto arg1 = Foam::min(
         Foam::min(
             Foam::max(sqrtK / (betaStar * omega * y), 500 * nu / (Foam::sqr(y) * omega)),
-            4 * alphaOmega2 * k / (CDkOmegaPlus() * Foam::sqr(y))
+            4 * alphaOmega2 * k / (cDkOmegaPlus() * Foam::sqr(y))
         ),
         Foam::dimensionedScalar("10", Foam::dimless, 10)
     );
@@ -90,14 +90,14 @@ Foam::volScalarField computeOfNut(
         Foam::max(2 * sqrtK / (betaStar * omega * y), 500 * nu / (Foam::sqr(y) * omega)),
         Foam::dimensionedScalar("100", Foam::dimless, 100)
     );
-    auto F2 = Foam::tanh(Foam::sqr(arg2));
+    auto f2 = Foam::tanh(Foam::sqr(arg2));
 
-    auto tgradU_tmp = fvc::grad(mesh.lookupObject<Foam::volVectorField>("U"));
-    const Foam::volTensorField& gradU = tgradU_tmp();
-    auto S2 = 2 * Foam::magSqr(Foam::symm(gradU));
-    auto sqrtS2 = Foam::sqrt(S2);
+    auto tgradUTmp = fvc::grad(mesh.lookupObject<Foam::volVectorField>("U"));
+    const Foam::volTensorField& gradU = tgradUTmp();
+    auto s2 = 2 * Foam::magSqr(Foam::symm(gradU));
+    auto sqrtS2 = Foam::sqrt(s2);
 
-    return Foam::volScalarField("ofNutComputed", a1 * k / Foam::max(a1 * omega, b1 * F2 * sqrtS2));
+    return Foam::volScalarField("ofNutComputed", a1 * k / Foam::max(a1 * omega, b1 * f2 * sqrtS2));
 }
 
 // ============================================================
@@ -195,9 +195,9 @@ TEST_CASE("kOmegaSST: component kernels match OpenFOAM")
             new Foam::volScalarField("t", tgradU() && Foam::devTwoSymm(tgradU()))
         )
     );
-    auto S2 = 2 * Foam::magSqr(Foam::symm(tgradU()));
+    auto s2 = 2 * Foam::magSqr(Foam::symm(tgradU()));
     auto sqrtK = Foam::sqrt(Foam::max(ofK, Foam::dimensionedScalar("0", ofK.dimensions(), 0)));
-    auto sqrtS2 = Foam::sqrt(S2);
+    auto sqrtS2 = Foam::sqrt(s2);
 
     // F2 (same computation as in correctNutInternal)
     auto arg2 = Foam::min(
@@ -207,16 +207,16 @@ TEST_CASE("kOmegaSST: component kernels match OpenFOAM")
         ),
         Foam::dimensionedScalar("100", Foam::dimless, 100)
     );
-    auto F2 = Foam::tanh(Foam::sqr(arg2));
+    auto f2 = Foam::tanh(Foam::sqr(arg2));
 
     // Blended coefficients
     Foam::volScalarField ofGamma("ofGamma", ofF1 * (gamma1 - gamma2) + gamma2);
     Foam::volScalarField ofBeta("ofBeta", ofF1 * (beta1 - beta2) + beta2);
 
     // G = nut * GbyNu0 (uses post-validate nut from OF)
-    auto G = ofNut * ofGbyNu0;
+    auto g = ofNut * ofGbyNu0;
     // Pk = min(G, c1*betaStar*k*omega)
-    Foam::volScalarField ofPk("ofPk", Foam::min(G, c1 * betaStar * ofK * ofOmega));
+    Foam::volScalarField ofPk("ofPk", Foam::min(g, c1 * betaStar * ofK * ofOmega));
 
     // spK = betaStar * omega
     Foam::volScalarField ofSpK("ofSpK", betaStar * ofOmega);
@@ -226,7 +226,7 @@ TEST_CASE("kOmegaSST: component kernels match OpenFOAM")
         "ofGbyNuBound",
         Foam::min(
             ofGbyNu0,
-            (c1 / a1) * betaStar * ofOmega * Foam::max(a1 * ofOmega, b1 * F2 * sqrtS2)
+            (c1 / a1) * betaStar * ofOmega * Foam::max(a1 * ofOmega, b1 * f2 * sqrtS2)
         )
     );
     // Cross-diffusion (actual, can be negative)


### PR DESCRIPTION
This pull request improves how NeoN is configured when OpenFOAM uses a different `WM_LABEL_SIZE` than NeoN expects.

### Motivation

OpenFOAM can be built with different label sizes, and NeoFOAM needs to handle those differences correctly during configuration. Without this adjustment, configuration fails in the `WM_LABEL_SIZE = 64` case.

### What changed

* Improved the NeoN configuration flow so it can adapt to the label size exposed by OpenFOAM.
* Replaced the previous approach of reaching internal implementation with a CMake-based configuration approach.
* Fixed formatting and cleanup related to this change.

### Why this matters

This makes NeoFOAM more robust across OpenFOAM builds with different label-size settings and avoids configuration failures caused by mismatched type assumptions.

### Related issue

Closes #367.
